### PR TITLE
Fixed link to Fork on GitHub

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
               <%- else -%>
                 <li><%= link_to 'Sign Up', new_user_registration_path %></li>
               <%- end -%>
-                <li><%= link_to "Fork on Github", "github.com/heroku/issue_triage" %></li>
+                <li><%= link_to "Fork on Github", "https://github.com/heroku/issue_triage" %></li>
             </ul>
           </div>
           <!--


### PR DESCRIPTION
Simply added https protocol so that it's not a relative link anymore.
