### PR TITLE
Added uniqueness validation when adding repositories.

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -64,7 +64,6 @@ class Repo < ActiveRecord::Base
     end
   end
 
-
   # This class is used by resque,
   # by default anything you put into the perform method
   # will be called for each object in the redis queue

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class RepoTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "uniqueness of repo" do
+    repo = Repo.create :user_name => 'refinery', :name => 'refinerycms'
+    duplicate_repo = Repo.create :user_name => 'refinery', :name => 'refinerycms'
+    assert_equal ["has already been taken"], duplicate_repo.errors[:name]
+  end
 end


### PR DESCRIPTION
P.S. You should delete the [duplicate rails repo](http://issuetriage.herokuapp.com/repos/17) and [duplicate refinerycms repo](http://issuetriage.herokuapp.com/repos/19)
