### PR TITLE
Add github avatars when signed in.

### DIFF
--- a/app/assets/stylesheets/screen.css
+++ b/app/assets/stylesheets/screen.css
@@ -2,7 +2,6 @@
   display: none;
 }
 
-
 .underline {
   text-decoration: underline;
 }
@@ -19,4 +18,8 @@ border-left-width: 0;
 
 a.btn:visited {
   color:white;
+}
+
+.navbar .nav img {
+  max-height: 40px;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   # Setup accessible (or protected) attributes for your model
-  attr_accessible :email, :password, :password_confirmation, :remember_me, :zip, :phone_number, :twitter, :github, :github_access_token
+  attr_accessible :email, :password, :password_confirmation, :remember_me, :zip, :phone_number, :twitter, :github, :github_access_token, :avatar_url
 
   has_many :repo_subscriptions
   has_many :repos, :through => :repo_subscriptions
@@ -36,8 +36,12 @@ class User < ActiveRecord::Base
 
   def self.find_for_github_oauth(auth, signed_in_resource=nil)
     user = signed_in_resource || User.where(:github => auth.info.nickname).first
-    params = { :github              => auth.info.nickname,
-               :github_access_token => auth.credentials.token }
+    params = {
+      :github              => auth.info.nickname,
+      :github_access_token => auth.credentials.token,
+      :avatar_url => auth.extra.raw_info.avatar_url
+    }
+
     if user
       user.update_attributes(params)
     else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,6 +42,7 @@
           <div class='nav-collapse'>
             <ul class='nav'>
               <%- if current_user.present? -%>
+                <li><%= image_tag current_user.avatar_url %>
                 <li><%= link_to "Sign Out (#{current_user.github})", destroy_user_session_path, :method => :delete %></li>
               <%- else -%>
                 <li><%= link_to 'Sign Up', new_user_registration_path %></li>

--- a/db/migrate/20121110213717_add_avatar_url_to_users.rb
+++ b/db/migrate/20121110213717_add_avatar_url_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarUrlToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :avatar_url, :string, :default => 'http://gravatar.com/avatar/default'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(:version => 20121112100015) do
   end
 
   create_table "users", :force => true do |t|
-    t.string   "email",                  :default => "", :null => false
-    t.string   "encrypted_password",     :default => "", :null => false
+    t.string   "email",                  :default => "",                                   :null => false
+    t.string   "encrypted_password",     :default => "",                                   :null => false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -65,8 +65,8 @@ ActiveRecord::Schema.define(:version => 20121112100015) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
+    t.datetime "created_at",                                                               :null => false
+    t.datetime "updated_at",                                                               :null => false
     t.string   "zip"
     t.string   "phone_number"
     t.boolean  "twitter"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(:version => 20121112100015) do
     t.string   "github_access_token"
     t.boolean  "admin"
     t.string   "name"
+    t.string   "avatar_url",             :default => "http://gravatar.com/avatar/default"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email", :unique => true


### PR DESCRIPTION
By default, users will see the default Gravatar. On their next sign-in with Github, their avatar will update.
- Fixes #3
- Also fixes an issue where `User#name` was being used to refer to github usernames instead of `User#github`.

In action:

![jroes signed in](http://i.imgur.com/tV3Yg.png)
