### PR TITLE
Add the word "leave" to triage mailer

### DIFF
--- a/app/views/user_mailer/send_triage.html.erb
+++ b/app/views/user_mailer/send_triage.html.erb
@@ -25,7 +25,7 @@ You signed up to help triage Github issues on <%= link_to @repo.username_repo, @
 First, carefully read over the issue, title, and description, if there are any comments read over all the comments, carefully. If a member of this repo is engaging actively there is no need to do anything, leaving a comment in the issue would just add to the clutter.
 </p>
 <p>
-If the issue hasn't been update in awhile, or if no one has commented consider the issue, if it is a bug try to reproduce it. If it is a pull request consider what an alternate implementation might look like. If there is something you don't understand about the issue and feel others will have that same question please your question in the comments. Be as descriptive as possible. Comments like "I don't understand this" are not helpful and counter productive. A better comment might be "Can you help me understand a use case for this?".
+If the issue hasn't been update in awhile, or if no one has commented consider the issue, if it is a bug try to reproduce it. If it is a pull request consider what an alternate implementation might look like. If there is something you don't understand about the issue and feel others will have that same question please leave your question in the comments. Be as descriptive as possible. Comments like "I don't understand this" are not helpful and counter productive. A better comment might be "Can you help me understand a use case for this?".
 </p>
 
 <p>


### PR DESCRIPTION
Found a small error in the mailer. I'm adding the missing word "leave" in this commit.
