### PR TITLE
"Send triage" should provide a link to main website

### DIFF
--- a/app/views/user_mailer/send_triage.html.erb
+++ b/app/views/user_mailer/send_triage.html.erb
@@ -48,5 +48,4 @@ If the issue goes stale, leave a comment asking if it is still a problem. If you
 
 <p><%= link_to "Send another #{@repo.username_repo} issue", repo_url(@repo) %></p>
 <p><%= link_to "Unsubscribe: #{@repo.username_repo}", repo_url(@repo) %></p>
-
-
+<p><%= link_to 'Help triage more repos at codetriage.com', root_url %></p>


### PR DESCRIPTION
It took some time for me to refresh site's name in my head, and google wasn't by my side in this situation. This commit adds link to other repos in the footer of mailing.
