### PR TITLE
Heroku-specific unicorn settings.

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,31 @@
-worker_processes 4 # amount of unicorn workers to spin up
-timeout 30         # restarts workers that hang for 30 seconds
+worker_processes 3
+timeout 30
+preload_app true
+
+before_fork do |server, worker|
+  # Replace with MongoDB or whatever
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.connection.disconnect!
+    Rails.logger.info('Disconnected from ActiveRecord')
+  end
+
+  # If you are using Redis but not Resque, change this
+  if defined?(Resque)
+    Resque.redis.quit
+    Rails.logger.info('Disconnected from Redis')
+  end
+end
+
+after_fork do |server, worker|
+  # Replace with MongoDB or whatever
+  if defined?(ActiveRecord::Base)
+    ActiveRecord::Base.establish_connection
+    Rails.logger.info('Connected to ActiveRecord')
+  end
+
+  # If you are using Redis but not Resque, change this
+  if defined?(Resque)
+    Resque.redis = ENV['REDIS_URI']
+    Rails.logger.info('Connected to Redis')
+  end
+end


### PR DESCRIPTION
Once or twice I've run into mysterious 500 errors. I think they may be
related to our missing the standard settings for handling connection
timeout issues on Heroku: https://gist.github.com/1401792

/cc @mattmanning
