### PR TITLE
Ignore dump.rdb.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 
 
 .env
+dump.rdb


### PR DESCRIPTION
Must have gotten mistakenly added to the index at some point.
