### PR TITLE
Add foreman, development group to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,12 +12,16 @@ gem 'resque'
 gem 'sextant'
 gem 'unicorn'
 gem 'omniauth-github'
-gem 'quiet_assets', :group => :development
 gem 'mail_view',          '~> 1.0.2'
 gem 'will_paginate'
 gem 'httparty'
 gem 'thin'
 gem 'dalli'
+
+group :development do
+  gem 'foreman'
+  gem 'quiet_assets'
+end
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     faraday (0.8.1)
       multipart-post (~> 1.1)
     ffi (1.1.5)
+    foreman (0.60.2)
+      thor (>= 0.13.6)
     hashie (1.2.0)
     hike (1.2.1)
     httparty (0.8.3)
@@ -217,6 +219,7 @@ DEPENDENCIES
   coffee-rails (~> 3.2.1)
   dalli
   devise (~> 2.0.4)
+  foreman
   httparty
   jquery-rails
   launchy


### PR DESCRIPTION
**README** says to run `foreman start` but foreman isn't in the Gemfile. This pull request adds foreman
 to a new `development` group and moves `quiet_assets` in there as well
