### PR TITLE
Allow users to add their own repos easily

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -9,6 +9,8 @@ class ReposController < ApplicationController
 
   def new
     @repo = Repo.new(user_name: params[:user_name], name: params[:name])
+    response = GitHubBub::Request.fetch("/user/repos", {type: "owner"}, current_user)
+    @own_repos = response.json_body
   end
 
   def show
@@ -33,6 +35,8 @@ class ReposController < ApplicationController
 
       redirect_to @repo
     else
+      response = GitHubBub::Request.fetch("/user/repos", {type: "owner"}, current_user)
+      @own_repos = response.json_body
       render :new
     end
   end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -88,6 +88,10 @@ class Repo < ActiveRecord::Base
     end
   end
 
+  def self.exists_with_name?(name)
+    Repo.all.collect{|r| r.username_repo}.include? name
+  end
+
   # This class is used by resque,
   # by default anything you put into the perform method
   # will be called for each object in the redis queue

--- a/app/views/repos/new.html.erb
+++ b/app/views/repos/new.html.erb
@@ -2,6 +2,34 @@
   <li><%= msg %></li>
 <% end %>
 
+<% if user_signed_in? %>
+  <h2>Your repos</h2>
+  <p>Only repos that you own, and have Github issues enabled are shown</p>
+  <table class="table table-striped">
+    <% @own_repos.each do |repo| %>
+      <% if repo["has_issues"] %>
+        <tr>
+          <%= form_for @repo do |f| %>
+            <%= f.hidden_field :user_name, :value => repo["full_name"].split("/").first %>
+            <%= f.hidden_field :name, :value => repo["full_name"].split("/").last %>
+            <td><%= repo["full_name"] %></td>
+            <td><%= repo["open_issues_count"] %> issues</td>
+            <td>
+              <% if  Repo.exists_with_name?(repo["full_name"]) %>
+                <p>Added!</p>
+              <% else -%>
+                <%= f.submit "Add", class: 'btn btn-mini btn-primary'  %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end -%>
+  <% end -%>
+  </table>
+<% end -%>
+
+<h3>Add another repo</h3>
+
 <%= form_for @repo do |f| %>
 
   https://github.com/

--- a/lib/git_hub_bub/request.rb
+++ b/lib/git_hub_bub/request.rb
@@ -4,11 +4,11 @@ module GitHubBub
     base_uri 'https://api.github.com'
     headers  'Accept' => 'application/vnd.github.3.raw+json'
 
-    def self.fetch(url, input_options = {})
+    def self.fetch(url, input_options = {}, current_user = nil)
       options = {}
       options[:query] = input_options
       url = "/#{url}" unless url =~ /^\//
-      # self.headers["Authorization"] = "token #{User.random_github_token}"
+      self.headers["Authorization"] = "token #{current_user.github_access_token}" if current_user.present?
       response    = self.get(url, options)
       GitHubBub::Response.create(response)
     end

--- a/test/integration/adding_repos_test.rb
+++ b/test/integration/adding_repos_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class AddingReposTest < ActionController::IntegrationTest
   test "adding a new valid repo" do
+    visit "/"
+    click_link "Add a Repo"
+    fill_in 'repo_user_name', :with => 'bemurphy'
+    fill_in 'repo_name', :with => 'issue_triage_sandbox'
+    click_button "Add Repo"
     VCR.use_cassette('add_valid_repo') do
-      visit "/"
-      click_link "Add a Repo"
-      fill_in 'repo_user_name', :with => 'bemurphy'
-      fill_in 'repo_name', :with => 'issue_triage_sandbox'
-      click_button "Add Repo"
       assert page.has_content?("Added bemurphy/issue_triage_sandbox for triaging")
     end
   end


### PR DESCRIPTION
So, this is something very rough that I've thrown together.  Essentially, if you're signed in, and go to add a repo, you're presented with a list of your own (eligible) repos that you can add (existing ones are show, but marked as added already).

Like I said, it's rough as hell, but works for now, and might entice people to add more repos.
