### PR TITLE
Remove extra hash from oauth data

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Github"
       sign_in_and_redirect @user, :event => :authentication
     else
-      session["devise.github_data"] = request.env["omniauth.auth"]
+      session["devise.github_data"] = request.env["omniauth.auth"].delete("extra")
       flash[:error] = no_email_error if request.env["omniauth.auth"].info.email.blank?
       redirect_to root_path
     end


### PR DESCRIPTION
A bit of digging has just turned up this (although this is Twitter)  http://stackoverflow.com/questions/7117200/devise-for-twitter-cookie-overflow-error

From looking at the Github data we also have this "extra" which could, in theory, overflow for some users.  We don't appear to need this so we can remove it before it's cast into session.
