### PR TITLE
Tooltip over subscribers has broken css

### DIFF
--- a/app/assets/stylesheets/screen.scss
+++ b/app/assets/stylesheets/screen.scss
@@ -98,3 +98,11 @@ hr {
     color: inherit;
   }
 }
+
+.popover {
+  background: transparent;
+  border: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}


### PR DESCRIPTION
There's a misplaced or misshaped background/border around the tooltip.

![ 2013-02-07 13-11-27](https://f.cloud.github.com/assets/118850/136623/caae21be-7151-11e2-953d-3318fc77c6f0.png)
