### PR TITLE
Include github callback url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ You now have Redis running on 6379.
 See the Download page on Redis.io for steps to install on other systems: [http://redis.io/download](http://redis.io/download)
 
 ### Environment
-If you want your users to sign up with Github, create a [GitHub Client Application](https://github.com/settings/applications), then add the credentials to your .env file:
+If you want your users to sign up with Github, create a [GitHub Client Application](https://github.com/settings/applications). The urls you are asked to provide will be something like this:
+
+- URL: `http://localhost:5000`
+- Callback URL: `http://localhost:5000/users/auth/github/callback`
+
+Then add the credentials to your .env file:
 
 ```shell
   $ echo GITHUB_APP_ID=foo >> .env


### PR DESCRIPTION
When setting up a github application for development, one will need to specify the callback url. This should be explicitly stated in the README.
