### PR TITLE
Raise error when trying to access github api returns error

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -147,6 +147,8 @@ class Repo < ActiveRecord::Base
   def update_from_github
     resp = GitHubBub::Request.fetch(repo_path)
 
+    raise UpdateRepoInfoError, resp.json_body['message'] unless resp.success?
+
     self.language    = resp.json_body['language']
     self.description = resp.json_body['description']
     self.save
@@ -167,6 +169,9 @@ class Repo < ActiveRecord::Base
       repo = Repo.find(repo_id)
       repo.update_from_github
     end
+  end
+
+  class UpdateRepoInfoError < Exception
   end
 
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -22,6 +22,13 @@ class RepoTest < ActiveSupport::TestCase
     end
   end
 
+  test "update repo info from github error" do
+    VCR.use_cassette "repo_info_error" do
+      repo = Repo.new :user_name => 'codetriage', :name => 'codetriage'
+      assert_raise(Repo::UpdateRepoInfoError) { repo.update_from_github }
+    end
+  end
+
   test "counts number of subscribers" do
     repo = Repo.create :user_name => 'Refinery', :name => 'Refinerycms'
     repo.users << users(:jroes)


### PR DESCRIPTION
Update repo info is silently failing if github api returns an error.
