### PR TITLE
Raise error when trying to access github api returns error

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -147,8 +147,6 @@ class Repo < ActiveRecord::Base
   def update_from_github
     resp = GitHubBub::Request.fetch(repo_path)
 
-    raise UpdateRepoInfoError, resp.json_body['message'] unless resp.success?
-
     self.language    = resp.json_body['language']
     self.description = resp.json_body['description']
     self.save
@@ -169,9 +167,6 @@ class Repo < ActiveRecord::Base
       repo = Repo.find(repo_id)
       repo.update_from_github
     end
-  end
-
-  class UpdateRepoInfoError < Exception
   end
 
 end

--- a/lib/git_hub_bub/request.rb
+++ b/lib/git_hub_bub/request.rb
@@ -17,7 +17,12 @@ module GitHubBub
       self.headers["Authorization"] = "token #{token}" if token.present?
 
       response    = self.get(url, options)
-      GitHubBub::Response.create(response)
+      gh_resp = GitHubBub::Response.create(response)
+      raise RequestError, gh_resp.json_body['message'] unless gh_resp.success?
+      gh_resp
     end
+  end
+
+  class RequestError < Exception
   end
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -25,7 +25,7 @@ class RepoTest < ActiveSupport::TestCase
   test "update repo info from github error" do
     VCR.use_cassette "repo_info_error" do
       repo = Repo.new :user_name => 'codetriage', :name => 'codetriage'
-      assert_raise(Repo::UpdateRepoInfoError) { repo.update_from_github }
+      assert_raise(GitHubBub::RequestError) { repo.update_from_github }
     end
   end
 


### PR DESCRIPTION
Update repo info is silently failing if github api returns an error.
