### PR TITLE
Tab click history

### DIFF
--- a/app/assets/javascripts/bootstrap.js.coffee
+++ b/app/assets/javascripts/bootstrap.js.coffee
@@ -12,3 +12,13 @@ jQuery ->
   $(".typeahead").typeahead()
 
   $("#repo-tabs a:first").tab 'show'
+
+  $("a[href=" + location.hash + "]").tab "show"  if location.hash
+  
+  $(document.body).on "click", "a[data-toggle]", (e) ->
+    location.hash = @getAttribute("href")
+    e.preventDefault()
+
+  $(window).on "popstate", ->
+    anchor = location.hash or $("a[data-toggle=tab]").first().attr("href")
+    $("a[href=" + anchor + "]").tab "show"


### PR DESCRIPTION
Clicking language tabs updates the URL hash allowing for bookmarking and history. Fixes #89.
