### PR TITLE
Authenticate every github call

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User < ActiveRecord::Base
 
   alias_attribute :token, :github_access_token
 
+  def self.random
+    order("RANDOM()")
+  end
+
   # users that are not subscribed to any repos
   def self.inactive
     joins("LEFT OUTER JOIN repo_subscriptions on users.id = repo_subscriptions.user_id").where("repo_subscriptions.user_id is null")

--- a/lib/git_hub_bub/request.rb
+++ b/lib/git_hub_bub/request.rb
@@ -6,9 +6,8 @@ module GitHubBub
 
     def self.fetch(url, input_options = {})
       options = {}
-      input_options ||= {}
 
-      token = input_options.delete(:token)
+      token = input_options.delete(:token) || User.random.first.try(:token)
 
       options[:query] = input_options
       url = "/#{url}" unless url =~ /^\//


### PR DESCRIPTION
Problem: Github is rate limiting Code Triage result resulting in repos with no issues and therefore plenty of users with no emails :(

Solution: Add a random github user token to EVERY CALL. Github gives you more calls when you're using a token. 

Do i love it: no. Will it work: probably.

Feedback? cc/ @neilmiddleton @parndt
