### PR TITLE
Provide plain-text mail

### DIFF
--- a/app/views/user_mailer/poke_inactive.text.erb
+++ b/app/views/user_mailer/poke_inactive.text.erb
@@ -1,22 +1,30 @@
 Hello <%= @user.github %>,
 
-You signed up to make a difference by triaging issues in github, which is great, but you didn't actually subscribe to any projects. To fix this just click on a link below, sign in, then click on the giant "subscribe" button:
+You signed up to make a difference by triaging issues in github, which is
+great, but you didn't actually subscribe to any projects. To fix this just
+click on a link below, sign in, then click on the giant "subscribe" button:
 
 Help the repo with the most issues:
-<%= link_to @most_repo.username_repo, repo_url(@most_repo) %>
+<%= @most_repo.username_repo %> (<%= repo_url(@most_repo) %>)
 
 Help a repo in need:
-<%= link_to @need_repo.username_repo , repo_url(@need_repo) %>
+<%= @need_repo.username_repo %> (<%= repo_url(@need_repo) %>)
 
 Help a random repo:
-<%= link_to @random_repo.username_repo, repo_url(@random_repo) %>
+<%= @random_repo.username_repo =%> (<%= repo_url(@random_repo) %>)
 
-If you don't like any of those <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , repos_url %> repos, or you can even subscribe to <%= link_to "code triage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.
+If you don't like any of those add your own repo (<%= new_repo_url %>), browse
+existing repos (<%= repos_url %>), or you can even subscribe to code triage
+itself (<%=  File.join(root_url, "/codetriage/codetriage") %>).
+The important part is that you pick something to triage, or you will get this
+same email next week, maybe with different repos.
 
-To unsubscribe entirely <%= link_to "delete your account", user_url(@user) %> but don't do that, subscribe to an issue above and do some good in the world. I believe in you.
+To unsubscribe entirely delete your account (<%= user_url(@user) %>) but don't
+do that, subscribe to an issue above and do some good in the world. I believe
+in you.
 
 --
-<%= link_to "@schneems", "http://twitter.com/schneems" %>
+@schneems (http://twitter.com/schneems)
 
 
-<%= link_to "unsubscribe", user_url(@user) %>
+unsubscribe: <%= user_url(@user) %>

--- a/app/views/user_mailer/send_triage.text.erb
+++ b/app/views/user_mailer/send_triage.text.erb
@@ -1,0 +1,56 @@
+Hello <%= @user.github %>,
+
+You signed up to help triage GitHub issues on <%= @repo.username_repo %> (<%= @repo.github_url %>).
+That's pretty awesome.
+
+Triage Issue: <%= @repo.username_repo %><%= "##{@issue.number}" if @issue.number %>
+
+<%= @issue.title %> (<%= @issue.html_url %>)
+
+Goals of Triage
+
+* Help share the weight of maintaining a project
+* Minimize un-needed issues
+* Prevent stale issues
+* Encourage productive communication
+* Teach good citizenship
+* To become a better coder
+
+How To Triage?
+
+First, carefully read over the issue, title, and description, if there are any
+comments read over all the comments, carefully. If a member of this repo is
+engaging actively there is no need to do anything, leaving a comment in the
+issue would just add to the clutter.
+
+If the issue hasn't been updated in awhile, or if no one has commented consider
+the issue, if it is a bug try to reproduce it. If it is a pull request consider
+what an alternate implementation might look like. If there is something you
+don't understand about the issue and feel others will have that same question
+please leave your question in the comments. Be as descriptive as possible.
+Comments like "I don't understand this" are not helpful and counter productive.
+A better comment might be "Can you help me understand a use case for this?".
+
+If you can reproduce the issue or you believe it is a good pull request, add a
+comment and say why you think that is. Try to stay positive while triaging
+issues, ask questions before you :-1: something. If you do decide to :+1: or
+:-1: on an issue, leave a comment as to why you feel that way. Issues are for
+social coding, if you help someone make better issues, you're helping the
+community.
+
+If the issue goes stale, leave a comment asking if it is still a problem. If
+you get no response for a number of days, you can leave another comment
+suggesting to the repo owner that they should close the issue.
+
+
+Go forth and make the world a better place
+
+Sincerely,
+@schneems
+(http://twitter.com/schneems)
+
+--
+
+Send another <%= @repo.username_repo %> issue: <%= repo_url(@repo) %>
+Unsubscribe from <%= @repo.username_repo %>: <%=  repo_url(@repo) %>
+Help triage more repos at codetriage.com: <%= root_url %>


### PR DESCRIPTION
Right now [send_triage.text.erb](https://github.com/codetriage/codetriage/blob/master/app/views/user_mailer/send_triage.text.erb) is empty
The html mail contains more or less just some text, would be easy to translate that into pure text with inline links.
