### PR TITLE
Group triage emails together 

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,6 +3,13 @@ require 'rails_autolink'
 class UserMailer < ActionMailer::Base
   default from: "Issue Triage <noreply@issuetriage.heroku.com>"
 
+  def send_daily_triage(options = {})
+    @user   = options[:user]
+    @issues = options[:issues]
+    subject = "Help Triage #{@issues.count} Open Source #{"Issue".pluralize(@issues.count)}"
+    mail(:to => @user.email, reply_to: "noreply@codetriage.com", subject: subject)
+  end
+
 
   def send_triage(options = {})
     @user   = options[:user]
@@ -41,6 +48,12 @@ class UserMailer < ActionMailer::Base
       repo  = Repo.last
       issue = Issue.where(state: "open").where("number is not null").last
       ::UserMailer.send_triage(:user => user, :repo => repo, :issue => issue)
+    end
+
+    def send_daily_triage
+      user   = User.last
+      issues = Issue.where(state: "open").where("number is not null").limit(rand(5) + 1)
+      ::UserMailer.send_daily_triage(user: user, issues: issues)
     end
 
     def poke_inactive

--- a/app/views/user_mailer/send_daily_triage.html.erb
+++ b/app/views/user_mailer/send_daily_triage.html.erb
@@ -1,0 +1,23 @@
+Hello @<%= @user.github %>,
+
+<p>Here are some issues you should check out:<p>
+
+<% @issues.each do |issue| %>
+  <p>
+    <h2 style='font-size: 1.1em'>
+      <%= "##{issue.number}" if issue.number %>
+      <%= link_to issue.title, issue.html_url  %>
+    </h2>
+    <p>
+    <small>
+       <%= link_to issue.repo.full_name, issue.repo %>
+       <%= time_ago_in_words issue.last_touched_at %>
+     </small>
+    <p>
+  </p>
+  <hr />
+<% end %>
+
+<p>Go forth and make the world a better place</p>
+<a href='http://twitter.com/schneems'>@schneems</p>
+

--- a/app/views/user_mailer/send_daily_triage.text.erb
+++ b/app/views/user_mailer/send_daily_triage.text.erb
@@ -1,0 +1,15 @@
+Hello @<%= @user.github %>,
+
+Here are some issues you should check out:
+
+<% @issues.each do |issue| %>
+  <%= "#{issue.repo.full_name}##{issue.number}" %>
+  <%= issue.title %>
+  (<%= issue.html_url %>)
+  <%= time_ago_in_words issue.last_touched_at %>
+<% end %>
+
+Go forth and make the world a better place
+@schneems (http://twitter.com/schneems)
+
+

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -2,7 +2,8 @@ namespace :schedule do
 
   desc "Sends triage emails"
   task :triage_emails => :environment do
-    RepoSubscription.queue_triage_emails!
+    # RepoSubscription.queue_triage_emails!
+    User.queue_triage_emails!
   end
 
   desc "Populates github issues"

--- a/test/unit/repo_subscriptions_test.rb
+++ b/test/unit/repo_subscriptions_test.rb
@@ -63,7 +63,7 @@ class RepoSubscriptionsTest < ActiveSupport::TestCase
 
     VCR.use_cassette('open_issue') do
       Issue.any_instance.stubs(:valid_for_user?).returns(true)
-      repo_sub.assign_issue!(false)
+      repo_sub.assign_issue!
       assert_equal 1, user.issue_assignments.count
     end
   end


### PR DESCRIPTION
This branch adds a new UserMailer method that accepts multiple issues and groups them into one single email. So if a user subscribes to 20 emails, they will get 1 email a day with 20 issues instead of 20 issues a day with 1 issue.

For now the older subscription notification code will not run and all users will receive a "digest" email once a day instead. In the future it would be trivial to add a flag to user accounts to allow them to opt to receive multiple emails instead.
