### PR TITLE
Redirect user to dashboard on update (with test) (re: #107)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,9 @@ class UsersController < ApplicationController
   def update
     @user = current_user
     @user.update_attributes(params[:user])
-    redirect_to :back
+    if @user.save!
+      redirect_to @user, :flash => { :success => 'User successfully updated' }
+    end
   end
 
   def destroy

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -48,9 +48,9 @@
         <h3 class="muted"><%= link_to "CodeTriage", root_path %></h3>
       </div>
 
-      <% [:notice, :error, :alert].each do |level| %>
+      <% [:notice, :error, :alert, :success].each do |level| %>
         <% unless flash[level].blank? %>
-          <div class="alert alert-block">
+          <div class='alert alert-block <%="alert-#{level}" %>'>
             <a class="close" data-dismiss="alert" href="#">&times;</a>
             <%= content_tag :p, flash[level] %>
           </div>

--- a/test/integration/user_update_test.rb
+++ b/test/integration/user_update_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class UserUpdateTest < ActionController::IntegrationTest
+  test 'updating the user email address' do
+    @user = User.first
+    visit edit_user_path(@user)
+    fill_in 'Email', :with => 'newemail@me.com'
+    click_button 'Save'
+    assert page.has_content?('User successfully updated')
+    assert_routing user_path(@user), { :controller => 'users', :action => 'show', :id => '1' }
+  end
+end
+
+


### PR DESCRIPTION
Here's an implementation with a test of redirecting the user back to their dashboard on successful update with a flash message. Addresses the issue I filed #107. 
