### PR TITLE
Add title to issues count

### DIFF
--- a/app/views/repos/_repo.html.erb
+++ b/app/views/repos/_repo.html.erb
@@ -1,4 +1,4 @@
-<span class="badge badge-info"><%= repo.issues_count %></span>
+<span class="badge badge-info" title="<%= repo.issues_count %> Issues"><%= repo.issues_count %></span>
 <h4>
   <%= link_to repo.name, repo %>
   <%= " <small>(#{repo.full_name})</small> ".html_safe if repo.full_name.present? %>


### PR DESCRIPTION
A simple number in a bubble is not always easy to know what
is it trying to say. Adding a title could give a tip.
