### PR TITLE
Handle invalid e-mail addresses better

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,9 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   def after_sign_in_path_for(resource)
-    if resource.new_record?
+    if !resource.valid_email?
+      edit_user_path(resource)
+    elsif resource.new_record?
       users_after_signup_index_path
     else
       super

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,7 +4,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.find_for_github_oauth(request.env["omniauth.auth"], current_user)
 
     if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "GitHub"
+      if @user.valid_email?
+        flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "GitHub"
+      else
+        flash[:notice] = I18n.t "devise.omniauth_callbacks.bad_email_success", :kind => "GitHub"
+      end
+
       sign_in_and_redirect @user, :event => :authentication
     else
       session["devise.github_data"] = request.env["omniauth.auth"].delete("extra")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,10 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :encryptable, :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :omniauthable
+         :recoverable, :rememberable, :trackable, :omniauthable
+
+  validates_uniqueness_of :email, :allow_blank => true, :if => :email_changed?
+  validates_length_of       :password, :within => 8..128, :allow_blank => true
 
   # Setup accessible (or protected) attributes for your model
   attr_accessible :private, :email, :password, :password_confirmation, :remember_me, :zip, :phone_number, :twitter, :github, :github_access_token, :avatar_url, :name
@@ -96,6 +99,15 @@ class User < ActiveRecord::Base
 
   def api_path
     "/user"
+  end
+
+  def valid_email?
+    begin
+      Mail::Address.new(email)
+      true
+    rescue
+      false
+    end
   end
 
   class InactiveEmail

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -48,6 +48,7 @@ en:
     omniauth_callbacks:
       success: 'Successfully authorized from %{kind} account.'
       failure: 'Could not authorize you from %{kind} because "%{reason}".'
+      bad_email_success: 'The e-mail address in your %{kind} account is not valid. Please set a legitimate one to receive e-mails from us.'
     mailer:
       confirmation_instructions:
         subject: 'Confirmation instructions'

--- a/test/functional/omniauth_callbacks_controller_test.rb
+++ b/test/functional/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class Users::OmniauthCallbacksControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+
+  setup do
+    request.env["devise.mapping"] = Devise.mappings[:user] 
+    request.env["omniauth.auth"] = OmniAuth.config.mock_auth[:github] 
+  end
+
+  should "make user feel good when legit email address" do
+    stub_oauth_user('legit@legit.com')
+    get :github
+    assert flash[:notice] == I18n.t("devise.omniauth_callbacks.success",
+                                    :kind => "GitHub")
+  end
+
+  should "redirect to user page and inform when bad e-mail address" do
+    user = stub_oauth_user('awful e-mail address')
+    get :github
+    assert flash[:notice] == I18n.t("devise.omniauth_callbacks.bad_email_success",
+                                    :kind => "GitHub")
+    assert_redirected_to edit_user_path(user)
+  end
+
+  def stub_oauth_user(email)
+    user = User.new(:email => email)
+    user.stubs(:persisted?).returns(true)
+    User.stubs(:find_for_github_oauth).returns(user)
+    user
+  end
+end

--- a/test/integration/user_update_test.rb
+++ b/test/integration/user_update_test.rb
@@ -10,5 +10,3 @@ class UserUpdateTest < ActionController::IntegrationTest
     assert_routing user_path(@user), { :controller => 'users', :action => 'show', :id => '1' }
   end
 end
-
-

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -52,4 +52,12 @@ class UserTest < ActiveSupport::TestCase
       user.send_daily_triage!
     end
   end
+
+  test 'valid_email? is true when valid' do
+    assert User.new(:email => 'richard.schneeman@gmail.com').valid_email?
+  end
+
+  test 'valid_email? is false when bad' do
+    assert !User.new(:email => 'a really bad e-mail address').valid_email?
+  end
 end


### PR DESCRIPTION
When a user signs up / signs in with an invalid e-mail address, they
will be taken to the user edit page and given a flash message
instructing them to use a valid e-mail address.

In handling this case, another hidden source of confusion has been
partially fixed -- when a user registers and their account does not
pass Devise's validations, the errors are swallowed and they are
redirected to the root path with no flash messaging. We now accept any
e-mail address provided by GitHub via OAuth and create the account
anyways, but redirect them to a page where they can set their e-mail
address on their own.

Closes #110.
