### PR TITLE
Missing or invalid User Agent string.

### DIFF
--- a/lib/git_hub_bub/request.rb
+++ b/lib/git_hub_bub/request.rb
@@ -4,7 +4,7 @@ module GitHubBub
   class Request
     include HTTParty
     base_uri 'https://api.github.com'
-    headers  'Accept' => 'application/vnd.github.3.raw+json'
+    headers  'Accept' => 'application/vnd.github.3.raw+json', "User-Agent"=>"codetriage"
 
     def self.fetch(url, input_options = {})
       options = {}


### PR DESCRIPTION
Github API now requires a "User-Agent" header: http://developer.github.com/v3/#user-agent-required
