### PR TITLE
Respond with HTTP 404 when the repo is not registered

### DIFF
--- a/app/controllers/repo_based_controller.rb
+++ b/app/controllers/repo_based_controller.rb
@@ -6,7 +6,9 @@ class RepoBasedController < ApplicationController
     end
 
     def find_repo(options)
-      name =  name_from_params(options)
-      Repo.includes(:issues).where(user_name: options[:user_name], name: name).first
+      user_name = options[:user_name]
+      name      = name_from_params(options)
+
+      Repo.find_by_user_name_and_name(user_name, name)
     end
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -180,4 +180,8 @@ class Repo < ActiveRecord::Base
     repo = Repo.find(id)
     repo.update_from_github
   end
+
+  def self.find_by_user_name_and_name(user_name, name)
+    Repo.includes(:issues).where(user_name: user_name, name: name).first!
+  end
 end

--- a/test/functional/repos_controller_test.rb
+++ b/test/functional/repos_controller_test.rb
@@ -1,5 +1,13 @@
 require 'test_helper'
 
 class ReposControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
 
+  fixtures :users, :repos
+
+  test 'responds with 404 if repo does not exist' do
+    assert_raise(ActiveRecord::RecordNotFound) {
+      get :show, user_name: 'foo', name: 'bar'
+    }
+  end
 end


### PR DESCRIPTION
Respond with HTTP 404 when the repo is not registered.

re #139 
