### PR TITLE
Use user_url to generate absolute path to user's profile in codetriage

### DIFF
--- a/app/views/user_mailer/send_daily_triage.html.erb
+++ b/app/views/user_mailer/send_daily_triage.html.erb
@@ -21,4 +21,4 @@ Hello @<%= @user.github %>,
 <p>Go forth and make the world a better place</p>
 <a href='http://twitter.com/schneems'>@schneems</p>
 <p><%= link_to 'Help triage more repos at codetriage.com', root_url %></p>
-<p><%= link_to 'Delete Account', @user %></p>
+<p><%= link_to 'Delete Account', user_url(@user) %></p>


### PR DESCRIPTION
- @user generated relative path `/users/:id`. We need absolute path,
  as this is going to be in the email
