### PR TITLE
Remove comment about sextant in routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,6 @@ Example::Application.routes.draw do
     mount UserMailer::Preview => 'mail_view'
   end
 
-  # mount_sextant if Rails.env.development?
-
   mount Resque::Server.new, :at => "/resque"
 
   # format: false gives us rails 3.0 style routes so angular/angular.js is interpreted as


### PR DESCRIPTION
As we are on rails 4 now, we can remove this comment.
