### PR TITLE
Using existential operator for userName and repoName values

### DIFF
--- a/app/assets/javascripts/preview_link_builder.js.coffee
+++ b/app/assets/javascripts/preview_link_builder.js.coffee
@@ -4,7 +4,7 @@ namespace 'Codetriage', (exports) ->
       defaultOptions = {
         "userNameInput"     : ".preview_user_name",
         "userRepoNameInput" : ".preview_repo_name",
-        "previewLink" : "#repo_preview"
+        "previewLink"       : "#repo_preview"
       }
 
       @options = $.extend({}, defaultOptions, customOptions)
@@ -13,8 +13,8 @@ namespace 'Codetriage', (exports) ->
       @updatePreviewLinkOnKeyup()
 
     createGithubUrl: ->
-      userName = $(@options.userNameInput).val().trim()
-      repoName = $(@options.userRepoNameInput).val().trim()
+      userName = $(@options.userNameInput).val()?.trim()
+      repoName = $(@options.userRepoNameInput).val()?.trim()
       "https://github.com/#{userName}/#{repoName}"
 
     checkPreviewUrl: ->


### PR DESCRIPTION
- TypeError: 'undefined' is not an object (evaluating
  '$(this.options.userNameInput).val().trim') error was coming because
  .preview_user_name and preview_repo_name elements were not present
  on all pages.
- Using existential operator, suppresses this error
