### PR TITLE
favorite languages is array. Map it to empty array. Closes #162

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,8 +43,8 @@ class UsersController < ApplicationController
         :github_access_token,
         :avatar_url,
         :name,
-        :favorite_languages,
-        :daily_issue_limit
+        :daily_issue_limit,
+        favorite_languages: []
         )
     end
 end


### PR DESCRIPTION
Acc. to strong params, only scalar params are available by default. So need to assign favorite_languages to array to allow it to be passed to model
