### PR TITLE
Handle authentication failure due to email change or Github nickname change. Fixes #173

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,7 +13,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, :event => :authentication
     else
       session["devise.github_data"] = request.env["omniauth.auth"].delete("extra")
-      flash[:error] = no_email_error if request.env["omniauth.auth"].info.email.blank?
+      flash[:error]  = no_email_error if request.env["omniauth.auth"].info.email.blank?
+      flash[:notice] = I18n.t "devise.omniauth_callbacks.failure",
+                       :kind => "GitHub", :reason => "Invalid credentials" if flash[:error].blank?
       redirect_to root_path
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,8 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :omniauthable
 
   validates_uniqueness_of :email, :allow_blank => true, :if => :email_changed?
-  validates_length_of       :password, :within => 8..128, :allow_blank => true
+  validates_length_of     :password, :within => 8..128, :allow_blank => true
+  validates :github, presence: true, uniqueness: true
 
   # Setup accessible (or protected) attributes for your model
 
@@ -72,7 +73,10 @@ class User < ActiveRecord::Base
   end
 
   def self.find_for_github_oauth(auth, signed_in_resource=nil)
-    user  = signed_in_resource || User.where(:github => auth.info.nickname).first
+    user  = signed_in_resource ||
+            User.where(:github => auth.info.nickname).first ||
+            User.where(:email  => auth.info.email).first
+
     token = auth.credentials.token
     params = {
       :github              => auth.info.nickname,

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -47,7 +47,7 @@ en:
       send_paranoid_instructions: 'If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.'
     omniauth_callbacks:
       success: 'Successfully authorized from %{kind} account.'
-      failure: 'Could not authorize you from %{kind} because "%{reason}".'
+      failure: 'Could not authorize you from %{kind} because of "%{reason}".'
       bad_email_success: 'The e-mail address in your %{kind} account is not valid. Please set a legitimate one to receive e-mails from us.'
     mailer:
       confirmation_instructions:


### PR DESCRIPTION
- Right now, if a user changes his/her email or Github nickname, he/she can't login.
- This PR tries to fix that issue by finding the user by email if it
  can't find it by nickname
- If a user has changed nickname, then email will be used to find
  the user
- If a user has changed email, nickname will be used to find the
  user
- If a user had changed both, the email and nickname, then a new user
  will be created
- Added uniqueness validation on user's github nickname so that
  database level uniqueness constraint will not throw the exception
