### PR TITLE
Fix the routing issue for /resque/resque

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Example::Application.routes.draw do
     mount UserMailer::Preview => 'mail_view'
   end
 
-  mount Resque::Server.new, :at => "/resque"
+  mount Resque::Server.new, :at => "/codetriage/resque"
 
   # format: false gives us rails 3.0 style routes so angular/angular.js is interpreted as
   # user_name: "angular", name: "angular.js" instead of using the "js" as a format


### PR DESCRIPTION
- As Resque is mounted before our username/reponame route,
  /resque/resque goes to mounted resque server and throws error that
  user is not authenticated.
- This commit mounts Resque to /codetriage/resque so /resque/\* will work
  fine.
- And we can see our resque-web from /codetriage/resque
