### PR TITLE
libv8 installtion errors out OSX Mavericks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :assets do
   gem 'coffee-rails', '~> 4.0.0'
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'uglifier', '>= 1.0.3'
-  gem 'therubyracer'
+  gem 'therubyracer', '~> 0.12.0'
   gem "less-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     less-rails (2.3.3)
       actionpack (>= 3.1)
       less (~> 2.3.1)
-    libv8 (3.11.8.17)
+    libv8 (3.16.14.3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -215,8 +215,8 @@ GEM
     teaspoon (0.7.4)
       phantomjs (>= 1.8.1.1)
       railties (>= 3.2.5, < 5)
-    therubyracer (0.11.4)
-      libv8 (~> 3.11.8.12)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
       ref
     thor (0.18.1)
     thread_safe (0.1.2)
@@ -286,7 +286,7 @@ DEPENDENCIES
   simplecov
   skylight
   teaspoon
-  therubyracer
+  therubyracer (~> 0.12.0)
   twitter-bootstrap-rails (~> 2.2.6)
   uglifier (>= 1.0.3)
   unicorn


### PR DESCRIPTION
Here's the error https://gist.github.com/railsaholic/7501185

Updating `therubyracer`  `libv8`  to the latest compatible versions

Feedback or any Concerns ? :smile: 
Thanks

Might or might not be linked to #185
