### PR TITLE
Avoid an unnecessary begin/rescue block

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,12 +117,7 @@ class User < ActiveRecord::Base
   end
 
   def valid_email?
-    begin
-      Mail::Address.new(email)
-      true
-    rescue
-      false
-    end
+    Mail::AddressListsParser.new.parse(email).present?
   end
 
   resque_def(:background_inactive_email) do |id|


### PR DESCRIPTION
The AddressListParser will return nil if the email is invalid
