### PR TITLE
Say devs are working on repos, otherwise reads as a list

### DIFF
--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -10,7 +10,7 @@
 
   <div class="jumbotron">
     <h2></h2>
-    <p class="lead"><%= number_with_delimiter(User.count, delimiter: ',') %> developers and working on <%= Repo.count %> open source repos</p>
+    <p class="lead"><%= number_with_delimiter(User.count, delimiter: ',') %> developers are working on <%= Repo.count %> open source repos</p>
   </div>
 
   <!-- yield -->


### PR DESCRIPTION
Currently it reads a little stiff, feels like you want to say you have a collective that is working together, which should be "are" in this case.

Do you agree?
