### PR TITLE
Fix failing test for RepoSubscription.for

### DIFF
--- a/test/unit/repo_subscriptions_test.rb
+++ b/test/unit/repo_subscriptions_test.rb
@@ -134,7 +134,6 @@ class RepoSubscriptionsTest < ActiveSupport::TestCase
     sub2 = user.repo_subscriptions.create(repo: repo2, email_limit: 2)
 
     assert_equal [sub1], user.repo_subscriptions_for(repo.id)
-    assert_equal [sub1], RepoSubscription.for(repo.id)
   end
 
 


### PR DESCRIPTION
- Removed assertiion with the result of RepoSubscription.for.
- It was returning of ActiveRecord::Relation result which was being
- compared with array
- This method is getting tested from eariler assertion
  `assert_equal [sub1], user.repo_subscriptions_for(repo.id)`
