### PR TITLE
Remove developers count for signed in users

### DIFF
--- a/app/views/layouts/home.html.erb
+++ b/app/views/layouts/home.html.erb
@@ -6,12 +6,12 @@
       <p class="lead">Sign up to receive a different open issue in your inbox every day from your favorite GitHub repos</p>
       <a class="btn btn-large btn-success" href="<%= new_user_registration_path %>">Sign up today</a>
     </div>
-  <% end -%>
 
-  <div class="jumbotron">
-    <h2></h2>
-    <p class="lead"><%= number_with_delimiter(User.count, delimiter: ',') %> developers are working on <%= Repo.count %> open source repos</p>
-  </div>
+    <div class="jumbotron">
+      <h2></h2>
+      <p class="lead"><%= number_with_delimiter(User.count, delimiter: ',') %> developers are working on <%= Repo.count %> open source repos</p>
+    </div>
+  <% end -%>
 
   <!-- yield -->
   <div class="row marketing">


### PR DESCRIPTION
This count is more of a marketing thing, and just takes up loads of space when
signed in and looking at your stuff.  Removing.
