### PR TITLE
Add eager_load config to avoid warnings on tests

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,5 +70,5 @@ Example::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.eager_load = false
+  config.eager_load = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,4 +30,6 @@ Example::Application.configure do
   config.active_support.deprecation = :stderr
 
   config.action_mailer.default_url_options = { :host => 'example.com' }
+
+  config.eager_load = false
 end


### PR DESCRIPTION
In order to avoid:

```
config.eager_load is set to nil. Please update your config/environments/*.rb files accordingly:

  * development - set it to false
  * test - set it to false (unless you use a tool that preloads your test environment)
  * production - set it to true
```

on tests, we could add those as described.

review @schneems
