### PR TITLE
Add asset dependencies on glyphicons images in bootstrap CSS to remove dependency error in development mode

### DIFF
--- a/app/assets/stylesheets/bootstrap.min.css.erb
+++ b/app/assets/stylesheets/bootstrap.min.css.erb
@@ -1,3 +1,5 @@
+//= depend_on_asset "glyphicons-halflings.png"
+//= depend_on_asset "glyphicons-halflings-white.png"
 /*!
  * Bootstrap v2.3.2
  *


### PR DESCRIPTION
- This change is required after merging 'sprockets_better_errors' gem. 
- Specified dependency on glyphicons images in the bootstrap CSS file
