### PR TITLE
 #230 Replace PUT with PATCH for repos

### DIFF
--- a/app/views/repos/show.html.erb
+++ b/app/views/repos/show.html.erb
@@ -26,7 +26,7 @@
 
 <p>
   <% if user_signed_in? && current_user.able_to_edit_repo?(@repo) %>
-    <%= link_to "Edit this repo", edit_repo_path(@repo), class: 'btn btn-mini' %>
+    <%= link_to "Edit this repo", edit_repo_path(@repo), class: 'btn btn-primary' %>
   <% end -%>
 
   <% if @repo_sub %>
@@ -79,5 +79,3 @@
     <% end %>
   </ul
 <hr />
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,10 +34,10 @@ CodeTriage::Application.routes.draw do
 
     scope ':full_name' do
       constraints full_name: REPO_PATH_PATTERN do
-        get '/',            to: 'repos#show',        as: 'repo'
-        put '/',            to: 'repos#update',      as:  nil
-        get '/edit',        to: 'repos#edit',        as: 'edit_repo'
-        get '/subscribers', to: 'subscribers#show',  as: 'repo_subscribers'
+        get   '/',            to: 'repos#show',        as: 'repo'
+        patch '/',            to: 'repos#update',      as:  nil
+        get   '/edit',        to: 'repos#edit',        as: 'edit_repo'
+        get   '/subscribers', to: 'subscribers#show',  as: 'repo_subscribers'
       end
     end
   end


### PR DESCRIPTION
- Rails 4 by default uses PATCH for updating records. So the Edit repo
  link generated PATCH link.
- Changing the route from PUT to PATCH, the incoming request is
  successfully directed to repos#update action.
- Fixes #230
