### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/schneems/puma_auto_tune.git
-  revision: a3a28753678524ac018cd9a28a084feec1751184
+  revision: d5c145128a37413463acc9055cebc494d91f9bf7
   specs:
     puma_auto_tune (0.0.1)
       get_process_mem (~> 0)


### PR DESCRIPTION
Gemfile.lock had a bad SHA for puma_auto_tune gem

@schneems
