### PR TITLE
Track last clicked issue

### DIFF
--- a/app/controllers/issue_assignments_controller.rb
+++ b/app/controllers/issue_assignments_controller.rb
@@ -4,4 +4,17 @@ class IssueAssignmentsController < ApplicationController
     repo_sub.send_triage_email!
     redirect_to :back, notice: 'You will receive an email with your new issue shortly'
   end
+
+
+  # get "/issue_assignments/:id/users/:user_id/click/:created_at", to: "issue_assignments#click"
+  def click_redirect
+    assignment = IssueAssignment.find(params[:id])
+    if assignment.present? && assignment.user.id.to_s == params[:user_id]
+      assignment.update_attributes(clicked: true)
+      assignment.user.update_attributes(last_clicked_at: Time.now)
+      redirect_to assignment.issue.html_url
+    else
+      redirect_to :root, message: "Bad url, if this problem persists please open an issue github.com/codetriage/codetriage"
+    end
+  end
 end

--- a/app/models/issue_assignment.rb
+++ b/app/models/issue_assignment.rb
@@ -3,11 +3,6 @@ class IssueAssignment < ActiveRecord::Base
   has_one     :user, :through => :repo_subscription
   has_one     :repo, :through => :repo_subscription
   belongs_to  :issue
-
-  validates :issue_id, :uniqueness => { :scope => :user_id }
-
-
-  validates_presence_of :user_id
-  validates_presence_of :issue_id
-
+  validates :repo_subscription_id, presence: true
+  validates :issue_id, :uniqueness => { :scope => :repo_subscription_id }, presence: true
 end

--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -1,10 +1,12 @@
 class RepoSubscription < ActiveRecord::Base
   include ResqueDef
 
-  validates :repo_id, :uniqueness => {:scope => :user_id}
+  validates :repo_id, :uniqueness => {:scope => :user_id}, presence: true
+  validates :user_id,  presence: true
 
   belongs_to :repo
   belongs_to :user
+
   has_many   :issue_assignments
 
   has_many   :issues, :through => :issue_assignments
@@ -68,7 +70,7 @@ class RepoSubscription < ActiveRecord::Base
     assignment.issue_id = issue.id
     assignment.user_id  = user.id
 
-    return issue if assignment.save
+    return assignment if assignment.save
   ensure
     self.update_attributes :last_sent_at => Time.now unless wait?
   end

--- a/app/views/user_mailer/send_daily_triage.md.erb
+++ b/app/views/user_mailer/send_daily_triage.md.erb
@@ -1,12 +1,15 @@
 Hello @<%= @user.github %>,
 
+<% if @days > @max_days %>
+It's been [<%= @days %> days] since you've clicked on a codetriage.com link, let's keep those issue counts down.
+<% end %>
 Here are some issues you should check out:
 
-<% @issues.each do |issue| %>
-### <%= "##{issue.number}" if issue.number %> <%= link_to issue.title, issue.html_url  %>
+<% @assignments.each do |assignment| %>
+### <%= "##{assignment.issue.number}" if assignment.issue.number %> <%= link_to assignment.issue.title, issue_click_path(assignment.id, assignment.user.id ) %>
 
-<%= "[#{issue.repo.full_name}](#{repo_url(issue.repo)})" %>
-<%= time_ago_in_words issue.last_touched_at %> ago
+<%= "[#{assignment.issue.repo.full_name}](#{repo_url(assignment.issue.repo)})" %>
+<%= time_ago_in_words assignment.issue.last_touched_at %> ago
 
 - - -
 
@@ -19,5 +22,3 @@ Go forth and make the world a better place
 [Help triage more repos at codetriage.com](<%= root_url%>)
 
 [Delete Account](<%= token_delete_user_url(@user.account_delete_token) %>)
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ CodeTriage::Application.routes.draw do
   delete      "/users/unsubscribe/:account_delete_token" => "users#token_destroy"
 
   resources   :issue_assignments
+
+  get "/issue_assignments/:id/users/:user_id/click", to: "issue_assignments#click_redirect", as: :issue_click
+
   resources   :repo_subscriptions
 
   if Rails.env.development?

--- a/db/migrate/20140524120051_add_click_to_issue_assignment.rb
+++ b/db/migrate/20140524120051_add_click_to_issue_assignment.rb
@@ -1,0 +1,7 @@
+class AddClickToIssueAssignment < ActiveRecord::Migration
+  def change
+    add_column :issue_assignments, :clicked,         :boolean,  default: false
+    add_column :users,             :last_clicked_at, :timestamp
+    User.find_each(&:save)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131107042958) do
+ActiveRecord::Schema.define(version: 20140524120051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,9 +19,10 @@ ActiveRecord::Schema.define(version: 20131107042958) do
   create_table "issue_assignments", force: true do |t|
     t.integer  "user_id"
     t.integer  "issue_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.integer  "repo_subscription_id"
+    t.boolean  "clicked",              default: false
   end
 
   create_table "issues", force: true do |t|
@@ -31,8 +32,8 @@ ActiveRecord::Schema.define(version: 20131107042958) do
     t.string   "user_name"
     t.datetime "last_touched_at"
     t.integer  "number"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.integer  "repo_id"
     t.string   "title"
     t.string   "html_url"
@@ -43,8 +44,8 @@ ActiveRecord::Schema.define(version: 20131107042958) do
   create_table "repo_subscriptions", force: true do |t|
     t.string   "user_name"
     t.string   "repo_name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.integer  "user_id"
     t.integer  "repo_id"
     t.datetime "last_sent_at"
@@ -54,13 +55,13 @@ ActiveRecord::Schema.define(version: 20131107042958) do
   create_table "repos", force: true do |t|
     t.string   "name"
     t.string   "user_name"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
     t.integer  "issues_count", default: 0, null: false
     t.string   "language"
     t.string   "description"
     t.string   "full_name"
     t.text     "notes"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   create_table "users", force: true do |t|
@@ -74,21 +75,22 @@ ActiveRecord::Schema.define(version: 20131107042958) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                                            null: false
+    t.datetime "updated_at",                                                            null: false
     t.string   "zip"
     t.string   "phone_number"
     t.boolean  "twitter"
     t.string   "github"
     t.string   "github_access_token"
     t.boolean  "admin"
-    t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
     t.string   "name"
+    t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
     t.boolean  "private",                default: false
     t.string   "favorite_languages",                                                                 array: true
     t.integer  "daily_issue_limit"
     t.boolean  "skip_issues_with_pr",    default: false
     t.string   "account_delete_token"
+    t.datetime "last_clicked_at"
   end
 
   add_index "users", ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -21,6 +21,7 @@ mockstar:
   name: Mock Star
   private: false
   favorite_languages: [ "ruby" ]
+  last_clicked_at: 2012-11-10 23:53:33.202139000 Z
 schneems:
   id: 2
   email: richard.schneeman@gmail.com
@@ -43,6 +44,7 @@ schneems:
   admin:
   name: Richard Schneeman
   private: false
+  last_clicked_at: 2012-11-10 23:53:33.202139000 Z
 jroes:
   id: 3
   email: jroes@jroes.net
@@ -65,3 +67,4 @@ jroes:
   admin:
   name: Jonathan Roes
   private: true
+  last_clicked_at: 2012-11-10 23:53:33.202139000 Z

--- a/test/unit/issue_assignment_test.rb
+++ b/test/unit/issue_assignment_test.rb
@@ -6,7 +6,6 @@ class IssueAssignmentTest < ActiveSupport::TestCase
     ia = IssueAssignment.new
     ia.valid?
     assert_equal ["can't be blank"], ia.errors[:issue_id]
-    assert_equal ["can't be blank"], ia.errors[:user_id]
   end
 
 end


### PR DESCRIPTION
This is step 1 in a multi step process to increase the usefulness and decrease the annoying factor of codetriage. We can start by keeping track of which issues people actually click.

We'll expose this information in the subject line when a user hasn't clicked on an email in a few days.

```
[5 days] Help Triage 5 Open Source Issues
```

Eventually we could use this information to send less emails. For instance if a user hasn't clicked on an email for the last 3 days, wait ~7 days before sending them another. We can always tweak this logic.

Either way the beginning point is tracking user clicks, and exposing that information

cc/ @olivierlacan @joannecheng
