### PR TITLE
Fix links in daily e-mail

### DIFF
--- a/app/views/user_mailer/send_daily_triage.md.erb
+++ b/app/views/user_mailer/send_daily_triage.md.erb
@@ -6,7 +6,7 @@ It's been [<%= @days %> days] since you've clicked on a codetriage.com link, let
 Here are some issues you should check out:
 
 <% @assignments.each do |assignment| %>
-### <%= "##{assignment.issue.number}" if assignment.issue.number %> <%= link_to assignment.issue.title, issue_click_path(assignment.id, assignment.user.id ) %>
+### <%= "##{assignment.issue.number}" if assignment.issue.number %> <%= link_to assignment.issue.title, issue_click_url(assignment.id, assignment.user.id ) %>
 
 <%= "[#{assignment.issue.repo.full_name}](#{repo_url(assignment.issue.repo)})" %>
 <%= time_ago_in_words assignment.issue.last_touched_at %> ago


### PR DESCRIPTION
E-mails are rendered with the link to the issue pointing at
`issue_assignments/<number>/users/<number>/click` instead of the
complete URL.

BTW, thanks for Codetriage! It [got me started contributing to Rails](http://contributors.rubyonrails.org/contributors/leandro-facchinetti/commits)!
