### PR TITLE
Add difficulty level tracking to Issues

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -82,7 +82,12 @@ class Issue < ActiveRecord::Base
                            last_touched_at: DateTime.parse(issue_hash['updated_at']),
                            state:           issue_hash['state'],
                            html_url:        issue_hash['html_url'],
-                           pr_attached:     pr_attached_with_issue?(issue_hash['pull_request']))
+                           pr_attached:     pr_attached_with_issue?(issue_hash['pull_request']),
+                           labels: label_names(issue_hash['labels']))
+  end
+
+  def label_names(labels)
+    labels.map { |label| label["name"] }
   end
 
   def self.queue_mark_old_as_closed!

--- a/db/migrate/20141011211605_add_labels_to_repo_subscriptions.rb
+++ b/db/migrate/20141011211605_add_labels_to_repo_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddLabelsToRepoSubscriptions < ActiveRecord::Migration
+  def change
+    add_column :repo_subscriptions, :labels, :string, array: true
+  end
+end

--- a/db/migrate/20141011211617_add_labels_to_issues.rb
+++ b/db/migrate/20141011211617_add_labels_to_issues.rb
@@ -1,0 +1,5 @@
+class AddLabelsToIssues < ActiveRecord::Migration
+  def change
+    add_column :issues, :labels, :string, array:true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140710164307) do
+ActiveRecord::Schema.define(version: 20141011211617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "issue_assignments", force: true do |t|
     t.integer  "issue_id"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_subscription_id"
     t.boolean  "clicked",              default: false
     t.boolean  "delivered",            default: false
@@ -34,58 +34,41 @@ ActiveRecord::Schema.define(version: 20140710164307) do
     t.string   "user_name"
     t.datetime "last_touched_at"
     t.integer  "number"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_id"
     t.string   "title"
     t.string   "html_url"
     t.string   "state"
     t.boolean  "pr_attached",     default: false
+    t.string   "level"
+    t.string   "labels",                          array: true
   end
 
-  create_table "opro_auth_grants", force: true do |t|
-    t.string   "code"
-    t.string   "access_token"
-    t.string   "refresh_token"
-    t.text     "permissions"
-    t.datetime "access_token_expires_at"
-    t.integer  "user_id"
-    t.integer  "application_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
-  create_table "opro_client_apps", force: true do |t|
-    t.string   "name"
-    t.string   "app_id"
-    t.string   "app_secret"
-    t.text     "permissions"
-    t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
+  add_index "issues", ["level"], name: "index_issues_on_level", using: :btree
 
   create_table "repo_subscriptions", force: true do |t|
     t.string   "user_name"
     t.string   "repo_name"
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "user_id"
     t.integer  "repo_id"
     t.datetime "last_sent_at"
     t.integer  "email_limit",  default: 1
+    t.string   "labels",                   array: true
   end
 
   create_table "repos", force: true do |t|
     t.string   "name"
     t.string   "user_name"
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
     t.integer  "issues_count",     default: 0, null: false
     t.string   "language"
     t.string   "description"
     t.string   "full_name"
     t.text     "notes"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.text     "github_error_msg"
   end
 
@@ -100,22 +83,23 @@ ActiveRecord::Schema.define(version: 20140710164307) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                                            null: false
-    t.datetime "updated_at",                                                            null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "zip"
     t.string   "phone_number"
     t.boolean  "twitter"
     t.string   "github"
     t.string   "github_access_token"
     t.boolean  "admin"
-    t.string   "name"
     t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
+    t.string   "name"
     t.boolean  "private",                default: false
     t.string   "favorite_languages",                                                                 array: true
     t.integer  "daily_issue_limit"
     t.boolean  "skip_issues_with_pr",    default: false
     t.string   "account_delete_token"
     t.datetime "last_clicked_at"
+    t.string   "level"
   end
 
   add_index "users", ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree


### PR DESCRIPTION
**This is a work in progress.**

I'm sending the pull request now to measure interest and gather feedback.

The idea is to allow anyone who can comment on an issue to comment
with a tag in the comment body that can inform CodeTriage of the
difficulty level of a particular issue.

The idea is that CodeTriage users should be able to select what
difficulty level(s) they are interested in, making CodeTriage
more useful for beginners and those who only feel comfortable
adding documentation.

Currently it uses whatever tag is last added to the comments.
This may not be the optimal method of picking tags.

Open questions:
- What levels are appropriate?
- Are multiple levels desired, (say "expert" and "documentation")?
- Is "codetriage-foo" a reasonable tag format or should something else be used?

I'm sure there are other things to discuss about this as well.

Feedback encouraged. :)
