### PR TITLE
Remove shoulda gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-# ruby '2.1.2'
-ruby "2.1.2", :patchlevel => "216"
+ruby '2.1.2'
+
 # Gems required in all environments
 gem 'rails', '4.1.2'
 
@@ -42,8 +42,6 @@ group :test do
   gem 'webmock'
   gem 'vcr'
   gem 'mocha', require: false
-  gem 'shoulda'
-  gem 'shoulda-matchers', github: 'thoughtbot/shoulda-matchers'
   gem 'simplecov', :require => false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,13 +14,6 @@ GIT
       get_process_mem (~> 0.1)
       puma (~> 2.7)
 
-GIT
-  remote: git://github.com/thoughtbot/shoulda-matchers.git
-  revision: 1511ed916156c6072cfba05b37f9f2c1bec2f0b6
-  specs:
-    shoulda-matchers (2.6.1)
-      activesupport (>= 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -210,10 +203,6 @@ GEM
       railties (>= 4.0.0.beta, < 5.0)
       sass (>= 3.1.10)
       sprockets-rails (~> 2.0.0)
-    shoulda (3.5.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (>= 1.4.1, < 3.0)
-    shoulda-context (1.1.4)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -302,8 +291,6 @@ DEPENDENCIES
   resque_def
   rrrretry
   sass-rails (~> 4.0.0)
-  shoulda
-  shoulda-matchers!
   simplecov
   skylight
   spring


### PR DESCRIPTION
- We are not using them in the tests.
- shoulda-context which is dependency of shoulda-matchers has a problem
  with  Ruby 2.2.0-preview1 which prevents us to upgrade to
  2.2.0-preview1.
- shoulda-context requires 'test/unit/testcase' which gives following
  error on Ruby 2.2.0-preview1 while running tests:

``` sh
  $ rake test
  rake aborted!
  LoadError: cannot load such file -- test/unit/testcase
```
