### PR TITLE
Mail bug fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'devise'
 gem 'rack-timeout'
 gem 'unicorn'
 gem 'mail_view',   '~> 1.0.2'
+gem 'valid_email'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    valid_email (0.0.10)
+      activemodel
+      mail (~> 2.6.1)
     vcr (2.5.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -293,6 +296,7 @@ DEPENDENCIES
   teaspoon
   uglifier (>= 1.0.3)
   unicorn
+  valid_email
   vcr
   webmock
   wicked

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,11 +126,7 @@ class User < ActiveRecord::Base
   end
 
   def valid_email?
-    begin
-      Mail::Parsers::AddressListsParser.new.parse(email).present?
-    rescue 
-      false
-    end
+    ValidateEmail.valid?(email)
   end
 
   resque_def(:background_inactive_email) do |id|


### PR DESCRIPTION
Changes: 
1. Updated rails to 4.1.7 and 10 failing tests. All because of change in the mail interface for parsing emails.
2.  In app/model/user.rb, 
   to parse an email,  the interface is changed to:
   Mail::Parsers::AddressListsParser.new.parse(email)
   After doing above change, 2 failing tests. Both case of trying to parse invalid emails, 
   ex:   Mail::Parsers::AddressListsParser.new.parse('my invalid email')
   This raises exception. Follow up on mail issues page(https://github.com/mikel/mail/issues/827)
3. In app/model/user.rb, 
   Rescued and returned false for valid email present whenever parsing exception from mail raised.
