### PR TITLE
 Change validate to validates for validating repo name

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -2,14 +2,13 @@ class Repo < ActiveRecord::Base
   include ResqueDef
 
   validate :github_url_exists, on: :create
-  validate :name, uniqueness: {scope: :user_name, case_sensitive: false }
+  validates :name, uniqueness: {scope: :user_name, case_sensitive: false }
 
   after_create :populate_issues!, :update_repo_info!
 
   before_validation :downcase_name, :strip_whitespaces
 
   validates :name, :user_name, presence: true
-  validates :name, uniqueness: {scope: :user_name}
 
   has_many :issues
   has_many :repo_subscriptions


### PR DESCRIPTION
- validate is used for custom validation but Rails > 4.2 does not
  complain even if we accidently call it with validates options.
- Rails 4.2 has raises exception that uniqueness option is not accepted
  by `validate` method.
- This looks like a typo where we wanted to call `validates`.
- Also removed a duplicate instance of `validates` which was validating
  repo name again.
