### PR TITLE
Speedup and fix Repo.exists_with_name?/1

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -122,7 +122,8 @@ class Repo < ActiveRecord::Base
   end
 
   def self.exists_with_name?(name)
-    Repo.all.collect{|r| r.username_repo}.include? name
+    uname, rname = name.downcase.split(?/)
+    Repo.exists?(user_name: uname, name: rname)
   end
 
   def self.order_by_subscribers


### PR DESCRIPTION
Stop iterating through all repos, and fix issue with button "Add" in `/repos/new` repos didn't marked as added if username/reponame have upcase letters.
