### PR TITLE
Removes extraneous 'Add a Repo' button

### DIFF
--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -3,5 +3,3 @@
 <%= render 'shared/repos', repos: @repos %>
 
 <%= will_paginate @repos %>
-
-<%= link_to "Add a Repo", new_repo_path, :class => 'btn btn-primary' %>


### PR DESCRIPTION
Hi.

This button seems to be unnecessary. There is already a 'Submit a Repo' button linking to `new_repo_path` that is rendered by the partial called in this view.

Wonderful idea! I hope to be able to contribute more soon.

All the best,
O-I