### PR TITLE
Excludes own issues and PRs from triage list

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,6 +60,7 @@ class UsersController < ApplicationController
         :name,
         :daily_issue_limit,
         :skip_issues_with_pr,
+        :skip_my_own_issues_and_prs,
         favorite_languages: []
         )
     end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -51,7 +51,7 @@ class Issue < ActiveRecord::Base
   end
 
   def created_by?(user)
-    user.github == self.creator
+    user.github == self.created_by
   end
 
   def repo_name
@@ -83,7 +83,7 @@ class Issue < ActiveRecord::Base
   def update_from_github_hash!(issue_hash)
     self.update_attributes(title:           issue_hash['title'],
                            url:             issue_hash['url'],
-                           creator:         issue_hash['user']['login'],
+                           created_by:      issue_hash['user']['login'],
                            last_touched_at: DateTime.parse(issue_hash['updated_at']),
                            state:           issue_hash['state'],
                            html_url:        issue_hash['html_url'],

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -16,8 +16,9 @@ class Issue < ActiveRecord::Base
       update_issue!
       return false if commenting_users.include?(user.github)
     end
-    return false  if closed?
-    return false  if pr_attached? && user.skip_issues_with_pr?
+    return false if closed?
+    return false if created_by?(user)
+    return false if pr_attached? && user.skip_issues_with_pr?
     true
   end
 
@@ -49,6 +50,10 @@ class Issue < ActiveRecord::Base
     state == OPEN
   end
 
+  def created_by?(user)
+    user.github == self.creator
+  end
+
   def repo_name
     self.repo.name
   end
@@ -78,6 +83,7 @@ class Issue < ActiveRecord::Base
   def update_from_github_hash!(issue_hash)
     self.update_attributes(title:           issue_hash['title'],
                            url:             issue_hash['url'],
+                           creator:         issue_hash['user']['login'],
                            last_touched_at: DateTime.parse(issue_hash['updated_at']),
                            state:           issue_hash['state'],
                            html_url:        issue_hash['html_url'],

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -17,7 +17,7 @@ class Issue < ActiveRecord::Base
       return false if commenting_users.include?(user.github)
     end
     return false if closed?
-    return false if created_by?(user)
+    return false if created_by?(user) && user.skip_my_own_issues_and_prs?
     return false if pr_attached? && user.skip_issues_with_pr?
     true
   end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -14,6 +14,9 @@
   <%= f.label :skip_issues_with_pr, t("activerecord.attributes.user.skip_issues_with_pr", :default => "Skip Issues with Pull requests"), :class => "label label-info" %>
   <%= f.check_box :skip_issues_with_pr, :class => 'checkbox' %>
 
+  <%= f.label :skip_my_own_issues_and_prs, t("activerecord.attributes.user.skip_my_own_issues_and_prs", :default => "Skip my own Issues and Pull requests"), :class => "label label-info" %>
+  <%= f.check_box :skip_my_own_issues_and_prs, :class => 'checkbox' %>
+
 </div>
 
 <div class="form-actions">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -22,6 +22,7 @@
 
       <h5>Max # of issues you want to receive per day: <%= @user.daily_issue_limit.presence || 'not set' %></h5>
       <h5>Skip Issues with Pull Requests: <%= @user.skip_issues_with_pr %></h5>
+      <h5>Skip my own Issues and Pull Requests: <%= @user.skip_my_own_issues_and_prs %></h5>
     </section>
 
     <section id="user-favorite-langs">

--- a/db/migrate/20150128225725_add_creator_to_issues.rb
+++ b/db/migrate/20150128225725_add_creator_to_issues.rb
@@ -1,0 +1,5 @@
+class AddCreatorToIssues < ActiveRecord::Migration
+  def change
+    add_column :issues, :creator, :string
+  end
+end

--- a/db/migrate/20150211163514_rename_creator_to_created_by_for_issues.rb
+++ b/db/migrate/20150211163514_rename_creator_to_created_by_for_issues.rb
@@ -1,0 +1,5 @@
+class RenameCreatorToCreatedByForIssues < ActiveRecord::Migration
+  def change
+    rename_column :issues, :creator, :created_by
+  end
+end

--- a/db/migrate/20150211235706_add_skip_my_own_issues_and_prs_to_users.rb
+++ b/db/migrate/20150211235706_add_skip_my_own_issues_and_prs_to_users.rb
@@ -1,0 +1,5 @@
+class AddSkipMyOwnIssuesAndPrsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :skip_my_own_issues_and_prs, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150211163514) do
+ActiveRecord::Schema.define(version: 20150211235706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,12 +69,12 @@ ActiveRecord::Schema.define(version: 20150211163514) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "",                                   null: false
-    t.string   "encrypted_password",     default: "",                                   null: false
+    t.string   "email",                      default: "",                                   null: false
+    t.string   "encrypted_password",         default: "",                                   null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0
+    t.integer  "sign_in_count",              default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -87,14 +87,15 @@ ActiveRecord::Schema.define(version: 20150211163514) do
     t.string   "github"
     t.string   "github_access_token"
     t.boolean  "admin"
-    t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
+    t.string   "avatar_url",                 default: "http://gravatar.com/avatar/default"
     t.string   "name"
-    t.boolean  "private",                default: false
-    t.string   "favorite_languages",                                                                 array: true
+    t.boolean  "private",                    default: false
+    t.string   "favorite_languages",                                                                     array: true
     t.integer  "daily_issue_limit"
-    t.boolean  "skip_issues_with_pr",    default: false
+    t.boolean  "skip_issues_with_pr",        default: false
     t.string   "account_delete_token"
     t.datetime "last_clicked_at"
+    t.boolean  "skip_my_own_issues_and_prs", default: false
   end
 
   add_index "users", ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140710164307) do
+ActiveRecord::Schema.define(version: 20150128225725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "issue_assignments", force: true do |t|
+  create_table "issue_assignments", force: :cascade do |t|
     t.integer  "issue_id"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_subscription_id"
     t.boolean  "clicked",              default: false
     t.boolean  "delivered",            default: false
@@ -27,94 +27,73 @@ ActiveRecord::Schema.define(version: 20140710164307) do
 
   add_index "issue_assignments", ["delivered"], name: "index_issue_assignments_on_delivered", using: :btree
 
-  create_table "issues", force: true do |t|
+  create_table "issues", force: :cascade do |t|
     t.integer  "comment_count"
-    t.string   "url",             limit: nil
-    t.string   "repo_name",       limit: nil
-    t.string   "user_name",       limit: nil
+    t.string   "url"
+    t.string   "repo_name"
+    t.string   "user_name"
     t.datetime "last_touched_at"
     t.integer  "number"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_id"
-    t.string   "title",           limit: nil
-    t.string   "html_url",        limit: nil
-    t.string   "state",           limit: nil
-    t.boolean  "pr_attached",                 default: false
+    t.string   "title"
+    t.string   "html_url"
+    t.string   "state"
+    t.boolean  "pr_attached",     default: false
+    t.string   "creator"
   end
 
-  create_table "opro_auth_grants", force: true do |t|
-    t.string   "code",                    limit: nil
-    t.string   "access_token",            limit: nil
-    t.string   "refresh_token",           limit: nil
-    t.text     "permissions"
-    t.datetime "access_token_expires_at"
-    t.integer  "user_id"
-    t.integer  "application_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-  end
-
-  create_table "opro_client_apps", force: true do |t|
-    t.string   "name",        limit: nil
-    t.string   "app_id",      limit: nil
-    t.string   "app_secret",  limit: nil
-    t.text     "permissions"
-    t.integer  "user_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
-  create_table "repo_subscriptions", force: true do |t|
-    t.string   "user_name",    limit: nil
-    t.string   "repo_name",    limit: nil
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+  create_table "repo_subscriptions", force: :cascade do |t|
+    t.string   "user_name"
+    t.string   "repo_name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "user_id"
     t.integer  "repo_id"
     t.datetime "last_sent_at"
-    t.integer  "email_limit",              default: 1
+    t.integer  "email_limit",  default: 1
   end
 
-  create_table "repos", force: true do |t|
-    t.string   "name",             limit: nil
-    t.string   "user_name",        limit: nil
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
-    t.integer  "issues_count",                 default: 0, null: false
-    t.string   "language",         limit: nil
-    t.string   "description",      limit: nil
-    t.string   "full_name",        limit: nil
+  create_table "repos", force: :cascade do |t|
+    t.string   "name"
+    t.string   "user_name"
+    t.integer  "issues_count",     default: 0, null: false
+    t.string   "language"
+    t.string   "description"
+    t.string   "full_name"
     t.text     "notes"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.text     "github_error_msg"
   end
 
-  create_table "users", force: true do |t|
-    t.string   "email",                  limit: nil, default: "",                                   null: false
-    t.string   "encrypted_password",     limit: nil, default: "",                                   null: false
-    t.string   "reset_password_token",   limit: nil
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  default: "",                                   null: false
+    t.string   "encrypted_password",     default: "",                                   null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: nil
-    t.string   "last_sign_in_ip",        limit: nil
-    t.datetime "created_at",                                                                        null: false
-    t.datetime "updated_at",                                                                        null: false
-    t.string   "zip",                    limit: nil
-    t.string   "phone_number",           limit: nil
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "zip"
+    t.string   "phone_number"
     t.boolean  "twitter"
-    t.string   "github",                 limit: nil
-    t.string   "github_access_token",    limit: nil
+    t.string   "github"
+    t.string   "github_access_token"
     t.boolean  "admin"
-    t.string   "name",                   limit: nil
-    t.string   "avatar_url",             limit: nil, default: "http://gravatar.com/avatar/default"
-    t.boolean  "private",                            default: false
-    t.string   "favorite_languages",     limit: nil,                                                             array: true
+    t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
+    t.string   "name"
+    t.boolean  "private",                default: false
+    t.string   "favorite_languages",                                                                 array: true
     t.integer  "daily_issue_limit"
-    t.boolean  "skip_issues_with_pr",                default: false
-    t.string   "account_delete_token",   limit: nil
+    t.boolean  "skip_issues_with_pr",    default: false
+    t.string   "account_delete_token"
     t.datetime "last_clicked_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150128225725) do
+ActiveRecord::Schema.define(version: 20150211163514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 20150128225725) do
     t.string   "html_url"
     t.string   "state"
     t.boolean  "pr_attached",     default: false
-    t.string   "creator"
+    t.string   "created_by"
   end
 
   create_table "repo_subscriptions", force: :cascade do |t|

--- a/test/integration/user_update_test.rb
+++ b/test/integration/user_update_test.rb
@@ -63,4 +63,26 @@ class UserUpdateTest < ActionDispatch::IntegrationTest
     @user.reload
     assert_equal false, @user.skip_issues_with_pr
   end
+
+  test 'updating the user\'s skip_my_own_issues_and_prs setting to true' do
+    @user = users(:mockstar)
+    login_as(@user, :scope => :user)
+    visit edit_user_path(@user)
+    check 'user_skip_my_own_issues_and_prs'
+    click_button 'Save'
+    assert page.has_content?('User successfully updated')
+    @user.reload
+    assert @user.skip_my_own_issues_and_prs?
+  end
+
+  test 'updating the user\'s skip_my_own_issues_and_prs setting to false' do
+    @user = users(:mockstar)
+    login_as(@user, :scope => :user)
+    visit edit_user_path(@user)
+    uncheck 'user_skip_my_own_issues_and_prs'
+    click_button 'Save'
+    assert page.has_content?('User successfully updated')
+    @user.reload
+    refute @user.skip_my_own_issues_and_prs?
+  end
 end

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -76,16 +76,28 @@ class IssueTest < ActiveSupport::TestCase
     assert issue.valid_for_user?(user, false), "issue is not valid for given user"
   end
 
-  test "valid_for_user? when issue was created by user" do
+  test "valid_for_user? when issue was created by user and skips own issues" do
     user  = users("mockstar")
     issue = repos("rails_rails").issues.new
     issue.stubs(:commenting_users).returns([])
     issue.stubs(:update_issue!).returns(true)
 
-    # should be false when the issue is the user's own
+    # should be false: issue is user's own and chooses to skip
     issue.stubs(:created_by).returns("mockstar")
-    refute issue.valid_for_user?(user, false),
-      "issue is not valid: it was created by the given user"
+    user.stubs(:skip_my_own_issues_and_prs?).returns(true)
+    refute issue.valid_for_user?(user, false), "issue is not valid for given user"
+  end
+
+  test "valid_for_user? when issue was created by user and does not skip own issues" do
+    user  = users("mockstar")
+    issue = repos("rails_rails").issues.new
+    issue.stubs(:commenting_users).returns([])
+    issue.stubs(:update_issue!).returns(true)
+
+    # should be true: issue is user's own and chooses not to skip
+    issue.stubs(:created_by).returns("mockstar")
+    user.stubs(:skip_my_own_issues_and_prs?).returns(false)
+    assert issue.valid_for_user?(user, false)
   end
 
   test 'commenting users' do

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -76,6 +76,18 @@ class IssueTest < ActiveSupport::TestCase
     assert issue.valid_for_user?(user, false), "issue is not valid for given user"
   end
 
+  test "valid_for_user? when user is the creator of issue" do
+    user  = users("mockstar")
+    issue = repos("rails_rails").issues.new
+    issue.stubs(:commenting_users).returns([])
+    issue.stubs(:update_issue!).returns(true)
+
+    # should be false when the issue is the user's own
+    issue.stubs(:creator).returns("mockstar")
+    refute issue.valid_for_user?(user, false),
+      "issue is not valid: it was created by the given user"
+  end
+
   test 'commenting users' do
     repo = repos("rails_rails")
     issue = repo.issues.new

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -76,14 +76,14 @@ class IssueTest < ActiveSupport::TestCase
     assert issue.valid_for_user?(user, false), "issue is not valid for given user"
   end
 
-  test "valid_for_user? when user is the creator of issue" do
+  test "valid_for_user? when issue was created by user" do
     user  = users("mockstar")
     issue = repos("rails_rails").issues.new
     issue.stubs(:commenting_users).returns([])
     issue.stubs(:update_issue!).returns(true)
 
     # should be false when the issue is the user's own
-    issue.stubs(:creator).returns("mockstar")
+    issue.stubs(:created_by).returns("mockstar")
     refute issue.valid_for_user?(user, false),
       "issue is not valid: it was created by the given user"
   end


### PR DESCRIPTION
Hi.

This pull request attempts to fix issue #304. I'm not sure if this is the best way to do this (or even if this is the desired behavior), so please review at your convenience and let me know how you'd like it changed.

Before these commits, the behavior was to exclude the following from a given user's triage list:
1. issues (and pull requests) the user has commented on
2. closed issues
3. pull requests when the user's `skip_issues_with_pr?` flag is set to `true`

However, a user's triage list would include one's own uncommented issues (and PRs if `skip_issues_with_pr?` is `false`). For example, if I subscribe to `codetriage/codetriage` and submit a pull request to which no one else responds, I could very well end up getting an email asking me to triage my own issue.

When an issue is created in the database, the user who created the issue isn't being stored anywhere. And the comments don't include any information on the user who originally filed the issue. So, I added a `creator` attribute to the `issues` table that stores the Github username of the person who filed the issue and used that to exclude one's own issues from a user's triage list.

Assuming this is an acceptable implementation, is this the behavior users want? I think it's reasonable to not want to see your own issues and PRs in your triage list, but I don't know — maybe it makes sense to some to have a `skip_my_own_issues?` setting.

Let me know your thoughts when you have time and I'd be happy to fix my fix however you'd like.

Cheers,
O-I
