### PR TITLE
Determine plurality of "issue" using .size method

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,7 +10,7 @@ class UserMailer < ActionMailer::Base
     subject = ""
     @days   = @user.days_since_last_clicked
     subject << "[#{@days} days] " if @days > @max_days
-    subject << "Help Triage #{@assignments.size} Open Source #{ "Issue".pluralize(@assignments.count)}"
+    subject << "Help Triage #{@assignments.size} Open Source #{"Issue".pluralize(@assignments.size)}"
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: subject)
   end
 


### PR DESCRIPTION
Changes `UserMailer.send_daily_triage()` to use `@assignments.size` as the argument to `"Issue".pluralize()` rather than `@assignments.count`. I'm not too familiar with Ruby so I don't know if this will actually fix the underlying issue, but I presume that since `@assignments.size` is returning the correct number of issues, then the behaviour will either become fixed or stay the same. Addresses #312.