### PR TITLE
.editorconfig to make a default indenting style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# @see http://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = spaces
+tab_width = 2
+
+[{*.{rb,erb,js,coffee,json,yml,css,scss,sh,markdown,md,html}]
+indent_size = 2


### PR DESCRIPTION
I've noticed recently that a lot of pull requests are getting dirty because of the different coding style of all contributors, so a way to try to get this to work is editorconfig. The contributors just need a plugin on their default Code Editor. 
Please check their website: http://editorconfig.org