### PR TITLE
Remove tmp bundler fix for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ rvm:
   - 2.2.2
 script:
   - RAILS_ENV=test bin/rake test
-before_install: gem install bundler -v=1.5.1
 before_script:
   - cp config/database.example.yml config/database.yml
   - psql -c 'create database triage_test;' -U postgres


### PR DESCRIPTION
Travis now bundled with higher bundler version, so we don't need to install it.