### PR TITLE
Reduce queries when rendering new repo page

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -94,7 +94,7 @@ class Repo < ActiveRecord::Base
 
   def self.exists_with_name?(name, repos)
     user_name, repo_name = name.downcase.split(?/)
-    repos.map { |r| r.full_name }.include?(name)
+    repos.map { |r| r.full_name }.include?("#{user_name}/#{repo_name}")
   end
 
   def self.order_by_subscribers

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -94,7 +94,7 @@ class Repo < ActiveRecord::Base
 
   def self.exists_with_name?(name, repos)
     user_name, repo_name = name.downcase.split(?/)
-    repos.map { |r| r.name }.include?(name)
+    repos.map { |r| r.full_name }.include?(name)
   end
 
   def self.order_by_subscribers

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -92,9 +92,9 @@ class Repo < ActiveRecord::Base
     background_populate_issues(self.id)
   end
 
-  def self.exists_with_name?(name)
+  def self.exists_with_name?(name, repos)
     user_name, repo_name = name.downcase.split(?/)
-    Repo.exists?(user_name: user_name, name: repo_name)
+    repos.map { |r| r.name }.include?(name)
   end
 
   def self.order_by_subscribers

--- a/app/views/repos/new.html.slim
+++ b/app/views/repos/new.html.slim
@@ -18,13 +18,13 @@
 
   .tab-content
     .tab-pane.active#own
-      = render 'shared/add_repos_list', repos: @own_repos
+      = render 'shared/add_repos_list', repos: @own_repos, all_repos: Repo.all
 
     .tab-pane.active#starred
-      = render 'shared/add_repos_list', repos: @starred_repos
+      = render 'shared/add_repos_list', repos: @starred_repos, all_repos: Repo.all
 
     .tab-pane.active#watched
-      = render 'shared/add_repos_list', repos: @watched_repos
+      = render 'shared/add_repos_list', repos: @watched_repos, all_repos: Repo.all
 
 h3 Add another repo
 

--- a/app/views/shared/_add_repos_list.html.slim
+++ b/app/views/shared/_add_repos_list.html.slim
@@ -15,7 +15,7 @@
             td= repo["full_name"]
             td #{repo["open_issues_count"]} issues
             td
-              - if Repo.exists_with_name?(repo["full_name"], current_user.repos)
+              - if Repo.exists_with_name?(repo["full_name"], all_repos)
                 p Added!
               - else
                 = f.submit "Add", class: 'btn btn-mini btn-primary'

--- a/app/views/shared/_add_repos_list.html.slim
+++ b/app/views/shared/_add_repos_list.html.slim
@@ -15,7 +15,7 @@
             td= repo["full_name"]
             td #{repo["open_issues_count"]} issues
             td
-              - if Repo.exists_with_name?(repo["full_name"])
+              - if Repo.exists_with_name?(repo["full_name"], current_user.repos)
                 p Added!
               - else
                 = f.submit "Add", class: 'btn btn-mini btn-primary'

--- a/db/migrate/20150504002726_add_index_to_repos.rb
+++ b/db/migrate/20150504002726_add_index_to_repos.rb
@@ -1,0 +1,6 @@
+class AddIndexToRepos < ActiveRecord::Migration
+  def change
+    add_index :repos, :name
+    add_index :repos, :user_name
+  end
+end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -67,8 +67,8 @@ class RepoTest < ActiveSupport::TestCase
   end
 
   test "check existence of repo by its name and user's name" do
-    assert Repo.exists_with_name?("bemurphy/issue_triage_sandbox")
-    refute Repo.exists_with_name?("prathamesh-sonpatki/issue_triage_sandbox")
+    assert Repo.exists_with_name?("bemurphy/issue_triage_sandbox", Repo.all)
+    refute Repo.exists_with_name?("prathamesh-sonpatki/issue_triage_sandbox", Repo.all)
   end
 
   test "#api_issues_path returns issues path with Github api" do


### PR DESCRIPTION
When rendering the new repos page, Repo#exists_with_name? was querying the database for each repo to see if it's already been added. I replaced these with a single query so each repo could be checked without going back to the database. I'm not sure what the performance difference will be on production, but on local I noticed a slight increase in speed. With multiple queries I was noticing a typical response of ~950ms to load the page, and with a single query it averaged ~750ms. This was when testing with my own GitHub account with just under 40 repos, so the performance gains will probably vary for users with more or less repos on their account.