### PR TITLE
Update email decider

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Make sure to remove any record modes from your VCR cassette before committing.
 
 ## Contact
 
-Richard Schneeman [@Schneems](http://twitter.com/schneems) for [Heroku](http://heroku.com).
+Richard Schneeman [@Schneems](http://twitter.com/schneems)
 
 Licensed under MIT License.
 Copyright (c) 2012 Schneems.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,7 @@
 require 'rails_autolink'
 
 class UserMailer < ActionMailer::Base
+  include ActionView::Helpers::DateHelper
   default from: "CodeTriage <noreply@codetriage.com>"
 
   def send_daily_triage(options = {})
@@ -9,7 +10,7 @@ class UserMailer < ActionMailer::Base
     @max_days    = 2
     subject = ""
     @days   = @user.days_since_last_clicked
-    subject << "[#{@days} days] " if @days > @max_days
+    subject << "[#{ time_ago_in_words(@days.days.ago).humanize }] " if @days > @max_days
     subject << "Help Triage #{@assignments.size} Open Source #{"Issue".pluralize(@assignments.size)}"
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: subject)
   end

--- a/app/models/email_decider.rb
+++ b/app/models/email_decider.rb
@@ -1,23 +1,29 @@
+# This class is used to determine the rate at which emails are sent.
+# We look at two parameters, the last day the user clicked on a link and the
+# last day we sent them an email. The idea is that we should send more active users
+# more emails. Less active users should get fewer emails so that it's less annoying.
 class EmailDecider
 
-  def initialize(clicked)
-    @days = clicked
+  def initialize(last_clicked_days_ago)
+    @last_clicked_days_ago = last_clicked_days_ago
   end
 
-  def skip?(sent)
-    !now?(sent)
+  def skip?(last_sent_days_ago)
+    !now?(last_sent_days_ago)
   end
 
   # send an email if you've clicked one in the last 3 days
   # back down to twice a week if they've not clicked in the last 7
-  def now?(sent)
-    case frequency
+  def now?(last_sent_days_ago)
+    case frequency_of_send_rate
     when :daily
       true
     when :once_a_week
-      sent.modulo(7).zero?
+      last_sent_days_ago.modulo(7).zero?
     when :twice_a_week
-      sent.modulo(3).zero?
+      last_sent_days_ago.modulo(3).zero?
+    when :once_a_month
+      last_sent_days_ago.modulo(30).zero?
     when :wait
       false
     else
@@ -26,14 +32,16 @@ class EmailDecider
   end
 
   private
-    def frequency
-      case @days
+    def frequency_of_send_rate
+      case @last_clicked_days_ago
       when 0..3
         :daily
       when 7..14
         :twice_a_week
-      when 14..Float::INFINITY
+      when 14..30
         :once_a_week
+      when 31..Float::INFINITY
+        :once_a_month
       else
         :wait
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,7 +152,9 @@ class User < ActiveRecord::Base
 
   def send_daily_triage!
     return false if repo_subscriptions.blank?
-    return false if EmailDecider.new(days_since_last_clicked).skip?(days_since_last_email)
+    skip = EmailDecider.new(days_since_last_clicked).skip?(days_since_last_email)
+    puts "User #{github}: skip: #{skip.inspect}, days_since_last_clicked: #{days_since_last_clicked}, days_since_last_email: #{days_since_last_email}"
+    return false if skip
 
     IssueAssigner.new(self, repo_subscriptions).assign
     ids         = repo_subscriptions.pluck(:id)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,10 +10,6 @@ html
         = render "flashes"
         = yield
       .footer
-        p
-          a.brand#heroku href="/"
-            ' by
-            strong heroku
     - if Rails.env.production?
       /! google analytics
       javascript:

--- a/test/unit/email_decider_test.rb
+++ b/test/unit/email_decider_test.rb
@@ -2,18 +2,44 @@ require 'test_helper'
 
 class EmailDeciderTest < ActiveSupport::TestCase
   test "decides email frequency" do
+    seed_array = [1,2,3,4,5,6,7]
     # daily
-    assert EmailDecider.new(rand(0..3)).now?(1)
+    last_clicked_days_ago = 0..3
+    multiplier            = 1
+    valid_values          = seed_array.map { |n| n * multiplier }
+    invalid_values        = last_clicked_days_ago.to_a - valid_values
+    assert EmailDecider.new(rand(last_clicked_days_ago)).now?(valid_values.sample)
 
     # wait
-    assert EmailDecider.new(rand(4..6)).skip?(1)
+    last_clicked_days_ago = 4..6
+    multiplier            = 1
+    valid_values          = seed_array.map { |n| n * multiplier }
+    invalid_values        = last_clicked_days_ago.to_a - valid_values
+    assert EmailDecider.new(rand(last_clicked_days_ago)).skip?(valid_values.sample)
+
 
     # twice a week
-    assert EmailDecider.new(rand(7..13)).now?([3, 6, 9, 12].sample)
-    assert EmailDecider.new(rand(7..13)).skip?([4, 7, 10, 13].sample)
+    last_clicked_days_ago = 7..13
+    multiplier            = 3
+    valid_values          = seed_array.map { |n| n * multiplier }
+    invalid_values        = last_clicked_days_ago.to_a - valid_values
+    assert EmailDecider.new(rand(last_clicked_days_ago)).now?(valid_values.sample)
+    assert EmailDecider.new(rand(last_clicked_days_ago)).skip?(invalid_values.sample)
 
     # once a week
-    assert EmailDecider.new(rand(14..100)).now?([7, 14, 21, 28].sample)
-    assert EmailDecider.new(rand(14..100)).skip?([8, 15, 22, 29].sample)
+    last_clicked_days_ago = 14..30
+    multiplier            = 7
+    valid_values          = seed_array.map { |n| n * multiplier }
+    invalid_values        = last_clicked_days_ago.to_a - valid_values
+    assert EmailDecider.new(rand(last_clicked_days_ago)).now?(valid_values.sample)
+    assert EmailDecider.new(rand(last_clicked_days_ago)).skip?(invalid_values.sample)
+
+    # once a month
+    last_clicked_days_ago = 31..10_000
+    multiplier            = 30
+    valid_values          = seed_array.map { |n| n * multiplier }
+    invalid_values        = last_clicked_days_ago.to_a - valid_values
+    assert EmailDecider.new(rand(last_clicked_days_ago)).now?(valid_values.sample)
+    assert EmailDecider.new(rand(last_clicked_days_ago)).skip?(invalid_values.sample)
   end
 end


### PR DESCRIPTION
- Added docs, improved variable names.
- Added ability to only send 1 email a month.
- Using time_ago_in_words on date in subject. I think the running date count accidentally encourages people to make the count go higher. 
- Added debugging info we can grep in papertrail for in production timing (i'm seeing behavior in production I cannot produce locally).
- Remove Heroku branding mention.