### PR TITLE
Flash error when user repeat unsubscribes

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,6 +34,9 @@ class UsersController < ApplicationController
 
   def token_delete
     @user = User.find_by(account_delete_token: params[:account_delete_token])
+    if @user.nil?
+      redirect_to root_url, notice: "Account could not be found. You may have already deleted it, or your GitHub username may have changed."
+    end
   end
 
   def token_destroy

--- a/test/integration/user_unsubscribes_test.rb
+++ b/test/integration/user_unsubscribes_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class UserUnsubscribeTest < ActionDispatch::IntegrationTest
+
+  # https://github.com/plataformatec/devise/wiki/How-To:-Test-with-Capybara
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  test 'unsubscribing successfully' do
+    @user = users(:mockstar)
+    token = @user.account_delete_token
+    login_as(@user, scope: :user)
+
+    visit token_delete_user_path(token)
+    click_on "Yes, Delete My Account"
+
+    assert page.has_content?('Successfully removed your user account')
+  end
+
+  test 'unsubscribing more than once' do
+    @user = users(:mockstar)
+    token = @user.account_delete_token
+    login_as(@user, scope: :user)
+
+    visit token_delete_user_path(token)
+    click_on "Yes, Delete My Account"
+
+    visit token_delete_user_path(token)
+
+    assert page.has_content?('Account could not be found. You may have already deleted it, or your GitHub username may have changed.')
+  end
+end


### PR DESCRIPTION
If a user clicks an unsubscribe link twice by mistake, instead of seeing a crash page they will be redirected and receive an flash notice. This will let them know that their account wasn't found and that either it was already deleted, or perhaps they changed their GitHub username since signing up. Discussed in #339.