### PR TITLE
Modify repo_subscriptions table

### DIFF
--- a/db/migrate/20150629002651_remove_repo_name_from_repo_subscriptions.rb
+++ b/db/migrate/20150629002651_remove_repo_name_from_repo_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveRepoNameFromRepoSubscriptions < ActiveRecord::Migration
+  def change
+    remove_column :repo_subscriptions, :repo_name
+  end
+end

--- a/db/migrate/20150629010617_remove_user_name_from_repo_subscriptions.rb
+++ b/db/migrate/20150629010617_remove_user_name_from_repo_subscriptions.rb
@@ -1,0 +1,5 @@
+class RemoveUserNameFromRepoSubscriptions < ActiveRecord::Migration
+  def change
+    remove_column :repo_subscriptions, :user_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150211235706) do
+ActiveRecord::Schema.define(version: 20150629010617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,14 +45,12 @@ ActiveRecord::Schema.define(version: 20150211235706) do
   end
 
   create_table "repo_subscriptions", force: :cascade do |t|
-    t.string   "user_name",    limit: 255
-    t.string   "repo_name",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
     t.integer  "repo_id"
     t.datetime "last_sent_at"
-    t.integer  "email_limit",              default: 1
+    t.integer  "email_limit",  default: 1
   end
 
   create_table "repos", force: :cascade do |t|

--- a/test/fixtures/repo_subscriptions.yml
+++ b/test/fixtures/repo_subscriptions.yml
@@ -1,8 +1,8 @@
 schneems_to_triage:
   repo: issue_triage_sandbox
   user: schneems
-  user_name: bemurphy
-  repo_name: issue_triage_sandbox
+  #user_name: bemurphy
+  #repo_name: issue_triage_sandbox
   created_at: 2013-10-29 21:09:48.351554000 Z
   updated_at: 2013-10-29 21:09:48.351554000 Z
   last_sent_at:
@@ -11,8 +11,8 @@ schneems_to_triage:
 jroes_to_rails:
   repo: rails_rails
   user: jroes
-  user_name: rails
-  repo_name: rails
+  #user_name: rails
+  #repo_name: rails
   created_at: 2013-10-29 21:09:48.351554000 Z
   updated_at: 2013-10-29 21:09:48.351554000 Z
   last_sent_at:


### PR DESCRIPTION
Removed the user_name and repo_name columns since they are not being used and the table already contains user_id and repo_id which references the corresponding user and repo for that particular repo_subscription.