### PR TITLE
Added footer with CodeTriage Github link and width fix

### DIFF
--- a/app/views/application/_footer.html.slim
+++ b/app/views/application/_footer.html.slim
@@ -1,0 +1,10 @@
+hr
+
+.container
+  .row-fluid
+    .span4
+    .span8
+      <iframe src="https://ghbtns.com/github-btn.html?user=codetriage&repo=codetriage&type=watch&count=true&v=2" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=codetriage&repo=codetriage&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=codetriage&repo=codetriage&type=fork&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+    p.text-center &copy CodeTriage 2015

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -4,7 +4,7 @@ html
   body
     a.hidden-xs href="https://github.com/codetriage/codetriage"
       img style="position: absolute; top: 0; left: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"
-    .container-narrow
+    .container
       .row-fluid
         = render "nav"
         = render "flashes"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,7 +9,8 @@ html
         = render "nav"
         = render "flashes"
         = yield
-      .footer
+      .footer  
+        = render "footer"
     - if Rails.env.production?
       /! google analytics
       javascript:


### PR DESCRIPTION
UPDATE: Changed container-narrow to container. Less whitespace and better looking IMO
![screen shot 2015-06-30 at 8 25 45 am](https://cloud.githubusercontent.com/assets/6161779/8421479/b5452dda-1f01-11e5-8eed-97a200ea9e1e.png)

container-narrow to container

![screen shot 2015-06-30 at 8 27 46 am](https://cloud.githubusercontent.com/assets/6161779/8421492/f0496a72-1f01-11e5-9e1c-f965d87c69da.png)
