### PR TITLE
Minor bug fix: Condition on empty starred repos on repos/new page.

### DIFF
--- a/app/views/shared/_add_repos_list.html.slim
+++ b/app/views/shared/_add_repos_list.html.slim
@@ -1,5 +1,7 @@
-- if repos.blank?
-  p None!
+- if repos.blank? || repos.count == 0
+  table.table.table-striped
+    tr
+      td None
 - else
   table.table.table-striped
     - repos.each do |repo|


### PR DESCRIPTION
OLD repos/new: 
![screen shot 2015-06-30 at 10 23 02 am](https://cloud.githubusercontent.com/assets/6015897/8423172/cfeb0c34-1f17-11e5-8115-d8cd32929382.png)

NEW repos/new:
![screen shot 2015-06-30 at 10 23 19 am](https://cloud.githubusercontent.com/assets/6015897/8423175/d4f6c8da-1f17-11e5-95f9-d7c19bdec07f.png)

Table now shows "None" when starred_repos is empty.