### PR TITLE
Cleanup users paths

### DIFF
--- a/app/views/users/after_signup/set_privacy.html.slim
+++ b/app/views/users/after_signup/set_privacy.html.slim
@@ -4,7 +4,7 @@ div style='height:50px; border: solid 1px black; display:inline-block; padding: 
   => image_tag current_user.avatar_url, class: 'img-rounded', style: "height: 40px; margin: 5px"
   | #{current_user.github} has subscribed to: #{link_to "codetriage/codetriage", "https://github.com/codetriage/codetriage"}
 p While we think this might be an awesome show of your commitment to quality code, you might not want this info public, if that's the case, we understand. You can make your account private by selecting the appropriate button below:
-= link_to "Make Private", next_wizard_path(user: {private: true}), method: :put,  class: "btn btn-primary"
-=<> link_to "Stay Public", next_wizard_path(user: {private: false}), method: :put, class: "btn btn-success"
+= link_to "Make Private", next_wizard_path(user: {private: true}), method: :patch,  class: "btn btn-primary"
+=<> link_to "Stay Public", next_wizard_path(user: {private: false}), method: :patch, class: "btn btn-success"
 = link_to "skip →", next_wizard_path, class: "btn btn-primary"
 p You can change your mind any time, and set your account to private on your settings page.

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -1,2 +1,0 @@
-= form_for @user, url: users_path, html: { class: :form } do |f|
-  = render partial: "form", locals: {f: f}

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,9 +11,9 @@
       small.muted Only visible to you
       h5 Publicly visible? : #{@user.public? ? "Yes" : "No"}
       - if @user.public?
-        = link_to "Stay private", users_path(user: {private: true}), method: :put, class: 'btn btn-warning'
+        = link_to "Stay private", user_registration_path(user: {private: true}), method: :patch, class: 'btn btn-warning'
       - else
-        = link_to "Go public", users_path(user: {private: false}), method: :put, class: 'btn btn-success'
+        = link_to "Go public", user_registration_path(user: {private: false}), method: :patch, class: 'btn btn-success'
       h5 Max # of issues you want to receive per day: #{@user.daily_issue_limit.presence || 'not set'}
       h5 Skip Issues with Pull Requests: #{@user.skip_issues_with_pr}
     section#user-favorite-langs

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,18 +2,24 @@ require 'resque/server'
 
 
 CodeTriage::Application.routes.draw do
-  get "users/sign_in" => redirect('/users/auth/github'), via: [:get, :post]
+  get "users/sign_in" => redirect('/users/auth/github'), via: [:get, :post], as: :new_user_registration
   get "users/sign_up" => redirect('/users/auth/github'), via: [:get, :post]
 
-  devise_for  :users, controllers: {omniauth_callbacks: "users/omniauth_callbacks",  registrations: "users"}
+  devise_for :users, skip: [:registrations], controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks"
+  }
+  as :user do
+    get 'users/edit' => 'users#edit', as: :edit_user_registration
+    patch 'users' => 'users#update', as: :user_registration
+  end
 
-  root        to: "pages#index"
+  root to: "pages#index"
 
   namespace :users do
     resources :after_signup
   end
 
-  resources   :users
+  resources   :users, except: [:new, :create, :index]
   get         "/users/unsubscribe/:account_delete_token" => "users#token_delete", as: :token_delete_user
   delete      "/users/unsubscribe/:account_delete_token" => "users#token_destroy"
 


### PR DESCRIPTION
We had 3 duplicated routes to `sign_up`. Also we had `/users` and `/users/new` without actual logic in controller. It's not trivial to remove unused user creation, thats why `devise_for` looks like this now, but it's still keeps `:registerable` in model.