### PR TITLE
Introduce help page

### DIFF
--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -1,13 +1,12 @@
 .masthead
   ul.nav.nav-pills.pull-right
+    li= link_to "Home", root_path
     - if user_signed_in?
-      li= link_to "Home", root_path
       li= link_to  "Repos", repos_path
       li= link_to current_user.github, current_user
       li= image_tag current_user.avatar_url, class: 'img-rounded', height: 30, width: 30
       li= link_to "Sign Out", destroy_user_session_path, method: :delete
     - else
-      li= link_to "Home", root_path
       li.active
         = link_to 'Sign in', new_user_registration_path
   h3.muted

--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -1,6 +1,8 @@
 .masthead
   ul.nav.nav-pills.pull-right
     li= link_to "Home", root_path
+    li= link_to "Help", help_path
+
     - if user_signed_in?
       li= link_to  "Repos", repos_path
       li= link_to current_user.github, current_user

--- a/app/views/pages/_goals_of_triage.html.slim
+++ b/app/views/pages/_goals_of_triage.html.slim
@@ -1,0 +1,29 @@
+h2 Goals of Triage
+
+ul
+  li Help share the weight of maintaining a project
+  li Minimize un-needed issues
+  li Prevent stale issues
+  li Encourage productive communication
+  li Teach good citizenship
+  li To become a better coder
+
+h2 How To Triage?
+
+p First, carefully read over the issue, title, and description, if there are any comments read over all the comments, carefully. If a member of this repo is engaging actively there is no need to do anything, leaving a comment in the issue would just add to the clutter.
+
+p If the issue hasn't been updated in awhile, or if no one has commented consider the issue, if it is a bug try to reproduce it. If it is a pull request consider what an alternate implementation might look like. If there is something you don't understand about the issue and feel others will have that same question please leave your question in the comments. Be as descriptive as possible. Comments like "I don't understand this" are not helpful and counter productive. A better comment might be "Can you help me understand a use case for this?".
+
+p If you can reproduce the issue or you believe it is a good pull request, add a comment and say why you think that is. Try to stay positive while triaging issues, ask questions before you :-1: something. If you do decide to :+1: or :-1: on an issue, leave a comment as to why you feel that way. Issues are for social coding, if you help someone make better issues, you're helping the community.
+
+p If the issue goes stale, leave a comment asking if it is still a problem. If you get no response for a number of days, you can leave another comment suggesting to the repo owner that they should close the issue.
+
+
+
+
+p Go forth and make the world a better place
+
+p Sincerely,
+
+p
+  a href='http://twitter.com/schneems' @schneems

--- a/app/views/pages/_goals_of_triage.text
+++ b/app/views/pages/_goals_of_triage.text
@@ -1,0 +1,25 @@
+Goals of Triage
+
+ * Help share the weight of maintaining a project
+ * Minimize un-needed issues
+ * Prevent stale issues
+ * Encourage productive communication
+ * Teach good citizenship
+ * To become a better coder
+
+How To Triage?
+
+First, carefully read over the issue, title, and description, if there are any comments read over all the comments, carefully. If a member of this repo is engaging actively there is no need to do anything, leaving a comment in the issue would just add to the clutter.
+
+If the issue hasn't been updated in awhile, or if no one has commented consider the issue, if it is a bug try to reproduce it. If it is a pull request consider what an alternate implementation might look like. If there is something you don't understand about the issue and feel others will have that same question please leave your question in the comments. Be as descriptive as possible. Comments like "I don't understand this" are not helpful and counter productive. A better comment might be "Can you help me understand a use case for this?".
+
+If you can reproduce the issue or you believe it is a good pull request, add a comment and say why you think that is. Try to stay positive while triaging issues, ask questions before you :-1: something. If you do decide to :+1: or :-1: on an issue, leave a comment as to why you feel that way. Issues are for social coding, if you help someone make better issues, you're helping the community.
+
+If the issue goes stale, leave a comment asking if it is still a problem. If you get no response for a number of days, you can leave another comment suggesting to the repo owner that they should close the issue.
+
+
+Go forth and make the world a better place
+
+Sincerely,
+@schneems
+(http://twitter.com/schneems)

--- a/app/views/pages/help.html.slim
+++ b/app/views/pages/help.html.slim
@@ -1,0 +1,1 @@
+= render partial: 'goals_of_triage'

--- a/app/views/user_mailer/send_daily_triage.md.erb
+++ b/app/views/user_mailer/send_daily_triage.md.erb
@@ -15,6 +15,8 @@ Here are some issues you should check out:
 
 <% end %>
 
+For a reminder on how to triage check out the <%= link_to 'help section', help_url %>
+
 Go forth and make the world a better place
 
 [@schneems](http://twitter.com/schneems)

--- a/app/views/user_mailer/send_triage.html.erb
+++ b/app/views/user_mailer/send_triage.html.erb
@@ -8,41 +8,7 @@ You signed up to help triage GitHub issues on <%= link_to @repo.path, @repo.gith
 
 <h2><%= link_to @issue.title, @issue.html_url %></h2>
 
-<h2>Goals of Triage</h2>
-
-<ul>
-  <li>Help share the weight of maintaining a project</li>
-  <li>Minimize un-needed issues</li>
-  <li>Prevent stale issues</li>
-  <li>Encourage productive communication</li>
-  <li>Teach good citizenship</li>
-  <li>To become a better coder</li>
-</ul>
-
-<h2>How To Triage?</h2>
-
-<p>
-First, carefully read over the issue, title, and description, if there are any comments read over all the comments, carefully. If a member of this repo is engaging actively there is no need to do anything, leaving a comment in the issue would just add to the clutter.
-</p>
-<p>
-If the issue hasn't been updated in awhile, or if no one has commented consider the issue, if it is a bug try to reproduce it. If it is a pull request consider what an alternate implementation might look like. If there is something you don't understand about the issue and feel others will have that same question please leave your question in the comments. Be as descriptive as possible. Comments like "I don't understand this" are not helpful and counter productive. A better comment might be "Can you help me understand a use case for this?".
-</p>
-
-<p>
-If you can reproduce the issue or you believe it is a good pull request, add a comment and say why you think that is. Try to stay positive while triaging issues, ask questions before you :-1: something. If you do decide to :+1: or :-1: on an issue, leave a comment as to why you feel that way. Issues are for social coding, if you help someone make better issues, you're helping the community.
-</p>
-
-<p>
-If the issue goes stale, leave a comment asking if it is still a problem. If you get no response for a number of days, you can leave another comment suggesting to the repo owner that they should close the issue.
-</p>
-
-
-
-
-<p>Go forth and make the world a better place</p>
-
-<p>Sincerely,</p>
-<a href='http://twitter.com/schneems'>@schneems</p>
+<%= render partial: '/pages/goals_of_triage' %>
 
 <hr />
 

--- a/app/views/user_mailer/send_triage.text.erb
+++ b/app/views/user_mailer/send_triage.text.erb
@@ -7,47 +7,8 @@ Triage Issue: <%= @repo.path %><%= "##{@issue.number}" if @issue.number %>
 
 <%= @issue.title %> (<%= @issue.html_url %>)
 
-Goals of Triage
 
-* Help share the weight of maintaining a project
-* Minimize un-needed issues
-* Prevent stale issues
-* Encourage productive communication
-* Teach good citizenship
-* To become a better coder
-
-How To Triage?
-
-First, carefully read over the issue, title, and description, if there are any
-comments read over all the comments, carefully. If a member of this repo is
-engaging actively there is no need to do anything, leaving a comment in the
-issue would just add to the clutter.
-
-If the issue hasn't been updated in awhile, or if no one has commented consider
-the issue, if it is a bug try to reproduce it. If it is a pull request consider
-what an alternate implementation might look like. If there is something you
-don't understand about the issue and feel others will have that same question
-please leave your question in the comments. Be as descriptive as possible.
-Comments like "I don't understand this" are not helpful and counter productive.
-A better comment might be "Can you help me understand a use case for this?".
-
-If you can reproduce the issue or you believe it is a good pull request, add a
-comment and say why you think that is. Try to stay positive while triaging
-issues, ask questions before you :-1: something. If you do decide to :+1: or
-:-1: on an issue, leave a comment as to why you feel that way. Issues are for
-social coding, if you help someone make better issues, you're helping the
-community.
-
-If the issue goes stale, leave a comment asking if it is still a problem. If
-you get no response for a number of days, you can leave another comment
-suggesting to the repo owner that they should close the issue.
-
-
-Go forth and make the world a better place
-
-Sincerely,
-@schneems
-(http://twitter.com/schneems)
+<%= render(partial: '/pages/goals_of_triage') %>
 
 --
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ CodeTriage::Application.routes.draw do
     patch 'users' => 'users#update', as: :user_registration
   end
 
+  get 'help' => 'pages#help'
+
   root to: "pages#index"
 
   namespace :users do


### PR DESCRIPTION
I was having trouble finding the original instructions that I received on how to triage.  This pull request:
- Makes a new section with those instructions
- Uses the same partial to render the instructions in the intro E-Mail
- Links to the help page from the daily E-Mails

I tried making the "_guide_to_triage" partial be a markdown file so that it could be both HTML and plain text like in the E-Mail templates, but I wasn't sure how to do that

This should address #337
