### PR TITLE
Add .digg_pagination class to Repos#index template pagination

### DIFF
--- a/app/views/repos/index.html.slim
+++ b/app/views/repos/index.html.slim
@@ -1,3 +1,3 @@
 h2 Subscribe To a Repo on GitHub
 = render 'repos', repos: @repos
-= will_paginate @repos
+.digg_pagination= will_paginate @repos


### PR DESCRIPTION
Fixes #393. 

Before: 
![bad_pagination](https://cloud.githubusercontent.com/assets/1680359/10258823/024e4834-691f-11e5-8ad2-b7d389db7e8b.png)

After: 
![fixed_pagination](https://cloud.githubusercontent.com/assets/1680359/10258834/286bd34c-691f-11e5-9e26-5c3051ddf069.png)

 