### PR TITLE
Don't show subscribed repos twice

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,7 +8,7 @@ class PagesController < ApplicationController
 
     if user_signed_in?
       @repos_subs = current_user.repo_subscriptions.page(valid_params[:page]).per_page( valid_params[:per_page] || 50).includes(:repo)
-      @repos = @repos.not_subbed_by(current_user)
+      @repos = @repos.not_subscribed_by(current_user)
     end
 
     respond_to do |format|

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,6 +8,7 @@ class PagesController < ApplicationController
 
     if user_signed_in?
       @repos_subs = current_user.repo_subscriptions.page(valid_params[:page]).per_page( valid_params[:per_page] || 50).includes(:repo)
+      @repos = @repos.not_subbed_by(current_user)
     end
 
     respond_to do |format|
@@ -18,6 +19,8 @@ class PagesController < ApplicationController
       end
     end
   end
+
+  private
 
   def valid_params
     params.permit(:language, :per_page, :page)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -161,6 +161,12 @@ class Repo < ActiveRecord::Base
     Repo.find_by!(full_name: full_name)
   end
 
+  def self.not_subbed_by(target_user)
+    subscribed_repo_ids = target_user.repos.map(&:id)
+    return all if subscribed_repo_ids.blank?
+    where('id NOT IN (?)', subscribed_repo_ids)
+  end
+
   private
 
   def downcase_name

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -161,7 +161,7 @@ class Repo < ActiveRecord::Base
     Repo.find_by!(full_name: full_name)
   end
 
-  def self.not_subbed_by(target_user)
+  def self.not_subscribed_by(target_user)
     subscribed_repo_ids = target_user.repos.map(&:id)
     return all if subscribed_repo_ids.blank?
     where('id NOT IN (?)', subscribed_repo_ids)


### PR DESCRIPTION
Don't show repos you're already subscribed to in the "Open source projects on GitHub that need your help" section