### PR TITLE
Add badges

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       rails_stdout_logging
     rails_autolink (1.1.6)
       rails (> 3.1)
-    rails_serve_static_assets (0.0.4)
+    rails_serve_static_assets (0.0.5)
     rails_stdout_logging (0.0.4)
     railties (5.0.0.beta3)
       actionpack (= 5.0.0.beta3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,3 +18,4 @@
 //= require tab_navigation
 //= require bootstrap
 //= require global
+//= require badge.js

--- a/app/assets/javascripts/badge.js
+++ b/app/assets/javascripts/badge.js
@@ -5,7 +5,7 @@ $(function() {
       var accordionTabs = $(this).closest('.accordion-tabs');
       accordionTabs.find('.is-open').removeClass('is-open').hide();
 
-      $(this).next().toggleClass('is-open').toggle();
+      $(this).next().toggleClass('is-open').show();
       accordionTabs.find('.is-active').removeClass('is-active');
       $(this).addClass('is-active');
     } else {

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -1,0 +1,15 @@
+$(function() {
+  $('.accordion-tabs').on('click', 'li > a.tab-link', function(event) {
+    if (!$(this).hasClass('is-active')) {
+      event.preventDefault();
+      var accordionTabs = $(this).closest('.accordion-tabs');
+      accordionTabs.find('.is-open').removeClass('is-open').hide();
+
+      $(this).next().toggleClass('is-open').toggle();
+      accordionTabs.find('.is-active').removeClass('is-active');
+      $(this).addClass('is-active');
+    } else {
+      event.preventDefault();
+    }
+  });
+})

--- a/app/assets/stylesheets/components/_accordion-tabs.scss
+++ b/app/assets/stylesheets/components/_accordion-tabs.scss
@@ -1,0 +1,42 @@
+.accordion-tabs {
+  $large-screen: em(860) !default;
+
+  @include clearfix;
+  padding: 0;
+
+  .tab-header-and-content {
+    list-style: none;
+
+    @include media($large-screen) {
+      display: inline;
+    }
+  }
+
+  .tab-link {
+    display: block;
+    padding-right: 1em;
+
+    @include media($large-screen) {
+      display: inline-block;
+    }
+  }
+
+  .is-active {
+    color: $codetriage-red;
+  }
+
+  .tab-content {
+    display: none;
+    width: 100%;
+    margin-top: $small-spacing;
+    float: left;
+
+    &.is-open {
+      display: block;
+    }
+
+    textarea {
+      height: 3.25rem;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/_repo-badge.scss
+++ b/app/assets/stylesheets/components/_repo-badge.scss
@@ -1,0 +1,3 @@
+.repo-badge {
+  float: right;
+}

--- a/app/assets/stylesheets/components/_repo.scss
+++ b/app/assets/stylesheets/components/_repo.scss
@@ -11,6 +11,12 @@
   }
 }
 
+.repo-badge {
+  @include media(38rem) {
+    float: right;
+  }
+}
+
 .repo-description {
   clear: both;
   color: $light-font-color;

--- a/app/views/repos/_badge.html.slim
+++ b/app/views/repos/_badge.html.slim
@@ -1,0 +1,23 @@
+- code_triagers_badge_url = File.join(repo_url(@repo), "badges/users.svg")
+
+ul.accordion-tabs
+  li.tab-header-and-content
+    a.is-active.tab-link href="javascript:void(0)" Image URL
+    .tab-content.is-open
+      textarea
+        = code_triagers_badge_url
+  li.tab-header-and-content
+    a.tab-link href="javascript:void(0)" Markdown
+    .tab-content
+      textarea
+        | [![Code Triagers Badge](#{code_triagers_badge_url})](#{repo_url(@repo)})
+  li.tab-header-and-content
+    a.tab-link href="javascript:void(0)" Textile
+    .tab-content
+      textarea
+        | !#{code_triagers_badge_url}!:#{repo_url(@repo)}
+  li.tab-header-and-content
+    a.tab-link href="javascript:void(0)" Rdoc
+    .tab-content
+      textarea
+        | {<img src='#{code_triagers_badge_url}' alt='Code Triagers Badge' />}[#{repo_url(@repo)}]

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -32,14 +32,17 @@ div class="subpage-content-wrapper #{ @repo.weight }"
     section.avatars.content-section
       h2.content-section-title
         = pluralize(@repo.subscribers.size, 'Subscriber'.pluralize())
-        a.repo-badge href="#{ repo_path(@repo) }"
-          img src="#{ File.join(repo_path(@repo), "badges/users.svg?count=#{@repo.subscribers.size}") }" /
-
       ul.avatars-list
         = render 'subscribers/avatars', subscribers: @subscribers, show_names: false
 
       - if (difference = @repo.subscribers.count - @subscribers.count) && difference > 0
         = link_to 'View all Subscribers' , repo_subscribers_path(full_name: @repo.full_name)
+
+    section.content-section
+      h2.content-section-title
+        | Add a CodeTriage badge to #{@repo.name}
+        img.repo-badge src="#{ File.join(repo_path(@repo), "badges/users.svg?count=#{@repo.subscribers.size}") }" /
+      = render partial: "badge"
 
     section.open-issues.content-section
       h2.content-section-title #{@repo.issues_count} open issues in #{@repo.path}

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -31,8 +31,9 @@ div class="subpage-content-wrapper #{ @repo.weight }"
 
     section.avatars.content-section
       h2.content-section-title
-        = pluralize(@repo.subscribers.count, 'Subscriber')
-        |  Triaging Issues
+        = pluralize(@repo.subscribers.size, 'Subscriber'.pluralize())
+        a.repo-badge href="#{ repo_path(@repo) }"
+          img src="#{ File.join(repo_path(@repo), "badges/users.svg?count=#{@repo.subscribers.size}") }" /
 
       ul.avatars-list
         = render 'subscribers/avatars', subscribers: @subscribers, show_names: false


### PR DESCRIPTION
Badges allow visitors to see at a glance how many people are subscribed to your project and, the "status" of issues. For now this is a hard coded value based on the number of issues, but we could change it to a ratio or something else more clever.

I worry that larger projects would shy away from putting a red badge on their repo, but then again maybe it would encourage them to keep issue counts low. Curious on other's thoughts here. Ideally a green badge should be a point of pride.

Here is a screen shot:

![](https://www.dropbox.com/s/dtz6hea9n1p70jb/Screenshot%202015-11-11%2013.47.46.png?dl=1)

When you click the badge you get a modal prompting you to copy the image url/markdown/etc.

![](https://www.dropbox.com/s/qqxr0l4ls7apn68/Screenshot%202015-11-11%2013.44.57.png?dl=1)

