### PR TITLE
Add badges

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,0 +1,31 @@
+class BadgesController < ApplicationController
+  def show
+    repo = Repo.where(full_name: permitted[:full_name]).first
+    raise ActionController::RoutingError.new('Not Found') if repo.blank?
+
+    case permitted[:badge_type]
+    when "users"
+      count = repo.users.count.to_s
+      key   = repo.cache_key + "/badges/".freeze + count
+
+      unless svg = Rails.cache.read(key)
+        result = Excon.get("https://img.shields.io/badge/code%20triagers-#{count}-#{repo.color}.svg")
+        raise ActionController::RoutingError.new('Not Found') unless result.status == 200
+        svg = result.body
+        Rails.cache.write(key, result.body, expires_in: 1.day)
+      end
+    else
+      raise ActionController::RoutingError.new('Not Found')
+    end
+
+    response.headers["Cache-Control"] = "public max-age=3600" # one hour
+    respond_to do |format|
+      format.svg { render text: svg }
+    end
+  end
+
+
+  def permitted
+    params.permit(:full_name, :badge_type)
+  end
+end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -18,10 +18,22 @@ class Repo < ActiveRecord::Base
     PopulateIssuesJob.perform_later(self.id)
   end
 
+  def color
+    case weight
+    when "low"
+      "5bb878".freeze
+    when "medium"
+      "eba117".freeze
+    when "high"
+      "e25443".freeze
+    else
+      "lightgrey".freeze
+    end
+  end
 
   def weight
     case issues_count
-    when 75..199
+    when 0..199
       "low".freeze
     when 200..799
       "medium".freeze

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "image/svg+xml", :svg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,10 +46,12 @@ CodeTriage::Application.routes.draw do
 
     scope '*full_name' do
       constraints full_name: REPO_PATH_PATTERN do
-        get   '/',            to: 'repos#show',        as: 'repo'
-        patch '/',            to: 'repos#update',      as:  nil
-        get   '/edit',        to: 'repos#edit',        as: 'edit_repo'
-        get   '/subscribers', to: 'subscribers#show',  as: 'repo_subscribers'
+        get   '/badges/:badge_type(.:format)', to: 'badges#show',       as: 'badge'
+
+        get   '/',              to: 'repos#show',        as: 'repo'
+        patch '/',              to: 'repos#update',      as:  nil
+        get   '/edit',          to: 'repos#edit',        as: 'edit_repo'
+        get   '/subscribers',   to: 'subscribers#show',  as: 'repo_subscribers'
       end
     end
   end


### PR DESCRIPTION
Badges allow visitors to see at a glance how many people are subscribed to your project and, the "status" of issues. For now this is a hard coded value based on the number of issues, but we could change it to a ratio or something else more clever.

I worry that larger projects would shy away from putting a red badge on their repo, but then again maybe it would encourage them to keep issue counts low. Curious on other's thoughts here. Ideally a green badge should be a point of pride.

Add a modal to the badge that gives url for easy copy