### PR TITLE
URI encode filter value for query string

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -72,7 +72,7 @@ javascript:
     function updateQueryStringParam(param, value) {
       baseUrl = [location.protocol, '//', location.host, location.pathname].join('');
       urlQueryString = document.location.search;
-      var newParam = param + '=' + value,
+      var newParam = param + '=' + encodeURIComponent(value),
       params = '?' + newParam;
 
       // If the "search" string exists, then build params from it


### PR DESCRIPTION
so that 'C#' is mapped to 'C%23' for language searches (issue #412)

I know in the issue you proposed changing the UI framework but it's simple enough to patch up the existing AJAX too.