### PR TITLE
Change from calc() to explicit value inside media query (Fixes: #422)

### DIFF
--- a/app/assets/stylesheets/components/_avatar.scss
+++ b/app/assets/stylesheets/components/_avatar.scss
@@ -4,12 +4,12 @@
   li {
     margin-bottom: $small-spacing;
 
-    @include media(max-width calc(25rem - 1px)) {
+    @include media(max-width 24.9375rem) {
       @include omega(2n);
       @include span-columns(6);
     }
 
-    @include media(min-width 25rem max-width calc(43rem - 1px)) {
+    @include media(min-width 25rem max-width 42.9375rem) {
       @include omega(3n);
       @include span-columns(4);
     }


### PR DESCRIPTION
iPhone 6+

<img width="405" alt="screen shot 2016-01-08 at 20 33 04" src="https://cloud.githubusercontent.com/assets/2222046/12207473/10f7a8b0-b647-11e5-9f1c-aba7f5aa1b7e.png">

iPhone 5

<img width="309" alt="screen shot 2016-01-08 at 20 33 13" src="https://cloud.githubusercontent.com/assets/2222046/12207474/10fef994-b647-11e5-9199-548c68a4e9c2.png">

Sorry for being a narcissist. I really like the picture :trollface: 
