### PR TITLE
Upgrade Rubygems according to bundler-audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.3.0'
 gem 'mime-types', '~> 2.6.1', require: 'mime/types/columnar'
 
 # Gems required in all environments
-gem 'rails', github: "rails/rails"
+gem 'rails', git: 'https://github.com/rails/rails.git'
 
 gem 'puma'
 gem 'puma_auto_tune'
@@ -22,7 +22,7 @@ gem 'bluecloth'
 gem 'maildown', '2.0.0'
 gem 'rrrretry'
 gem 'jquery-rails'
-gem 'devise', github: 'plataformatec/devise'
+gem 'devise', git: 'https://github.com/plataformatec/devise.git'
 gem 'rack-timeout'
 gem 'mail_view', '~> 1.0.2'
 gem 'valid_email'
@@ -39,12 +39,12 @@ group :development do
   gem 'foreman'
   gem 'quiet_assets'
   gem 'spring'
-  gem 'web-console', github: "rails/web-console" #'~> 2.0'
+  gem 'web-console'
   gem 'bullet', '5.0.0'
 end
 
 group :test do
-  gem 'capybara', github: 'jnicklas/capybara' # '2.5.0'
+  gem 'capybara', git: 'https://github.com/jnicklas/capybara.git' # '2.5.0'
   # Not essential but helpful for save_and_open_page
   gem 'launchy'
   gem 'webmock'
@@ -73,5 +73,5 @@ gem 'aws-sdk', '~> 2'
 gem 'multi_fetch_fragments'
 
 gem 'mail', require: ['mail', 'mail/utilities', 'mail/parsers'] # parsers is used by `valid_email` and may be causing https://github.com/mikel/mail/issues/912#issuecomment-170121429
-gem 'oauth2', github: 'intridea/oauth2'
-gem 'record_tag_helper', github: 'rails/record_tag_helper'
+gem 'oauth2', git: 'https://github.com/intridea/oauth2.git'
+gem 'record_tag_helper', git: 'https://github.com/rails/record_tag_helper.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/intridea/oauth2.git
+  remote: https://github.com/intridea/oauth2.git
   revision: 43e1fdd87e95a5b02438d5cce6a67e411afb5fec
   specs:
     oauth2 (1.0.0)
@@ -10,10 +10,11 @@ GIT
       rack (>= 1.2, < 3)
 
 GIT
-  remote: git://github.com/jnicklas/capybara.git
-  revision: 4b3093f4bd12a682b41d8e88d3958d33e70f4662
+  remote: https://github.com/jnicklas/capybara.git
+  revision: 3f5c36f1a45e0f05365539524ee17adb20a7c8d5
   specs:
-    capybara (2.6.0.dev)
+    capybara (2.7.0.dev)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -21,10 +22,10 @@ GIT
       xpath (~> 2.0)
 
 GIT
-  remote: git://github.com/plataformatec/devise.git
-  revision: a321282ccc93d73f9d0f7a1319d3fcab27d25b20
+  remote: https://github.com/plataformatec/devise.git
+  revision: ffe9d6d406e79108cf32a2c6a1d0b3828849c40b
   specs:
-    devise (3.5.3)
+    devise (4.0.0.pre.dev)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -32,13 +33,14 @@ GIT
       warden (~> 1.2.3)
 
 GIT
-  remote: git://github.com/rails/rails.git
-  revision: c48790e4f6d3b733c55e7812f10ccad220ee7f81
+  remote: https://github.com/rails/rails.git
+  revision: 4de092240004e31c512810b19e1b7a83e1ddc77e
   specs:
     actioncable (5.0.0.beta1.1)
       actionpack (= 5.0.0.beta1.1)
       coffee-rails (~> 4.1.0)
-      nio4r (~> 1.2)
+      eventmachine (~> 1.0)
+      faye-websocket (~> 0.10.0)
       websocket-driver (~> 0.6.1)
     actionmailer (5.0.0.beta1.1)
       actionpack (= 5.0.0.beta1.1)
@@ -95,20 +97,11 @@ GIT
       thor (>= 0.18.1, < 2.0)
 
 GIT
-  remote: git://github.com/rails/record_tag_helper.git
+  remote: https://github.com/rails/record_tag_helper.git
   revision: 0eaf03ab6a185560508f660c6f191e9ae85a3340
   specs:
     record_tag_helper (1.0.0)
       actionview (>= 5.x, < 6.0)
-
-GIT
-  remote: git://github.com/rails/web-console.git
-  revision: 0991238f6745e0f045edc40592ac09693bfd2f36
-  specs:
-    web-console (3.0.0)
-      activemodel (>= 4.2)
-      debug_inspector
-      railties (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -161,10 +154,14 @@ GEM
       dotenv (= 2.1.0)
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
+    eventmachine (1.0.9.1)
     excon (0.45.4)
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faye-websocket (0.10.2)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     foreman (0.78.0)
       thor (~> 0.19.1)
     get_process_mem (0.2.0)
@@ -214,7 +211,6 @@ GEM
     neat (1.7.2)
       bourbon (>= 4.0)
       sass (>= 3.3)
-    nio4r (1.2.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     normalize-rails (3.0.3)
@@ -314,8 +310,12 @@ GEM
       activemodel
       mail (~> 2.6.1)
     vcr (2.9.3)
-    warden (1.2.4)
+    warden (1.2.5)
       rack (>= 1.0)
+    web-console (3.1.1)
+      activemodel (>= 4.2)
+      debug_inspector
+      railties (>= 4.2)
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -380,7 +380,7 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   valid_email
   vcr
-  web-console!
+  web-console
   webmock
   wicked
   will_paginate (= 3.1.0)


### PR DESCRIPTION
This Pull Request fix vulnerable gems according to [bundler-audit](https://github.com/rubysec/bundler-audit):

```
$ bundle-audit
Insecure Source URI found: git://github.com/jnicklas/capybara.git
Insecure Source URI found: git://github.com/matthewrudy/oauth2.git
Insecure Source URI found: git://github.com/plataformatec/devise.git
Insecure Source URI found: git://github.com/rails/rails.git
Insecure Source URI found: git://github.com/rails/record_tag_helper.git
Insecure Source URI found: git://github.com/rails/web-console.git
Name: devise
Version: 3.5.3
Advisory: CVE-2015-8314
Criticality: Unknown
URL: http://blog.plataformatec.com.br/2016/01/improve-remember-me-cookie-expiration-in-devise/
Title: Devise Gem for Ruby Unauthorized Access Using Remember Me Cookie
Solution: upgrade to >= 3.5.4

Vulnerabilities found!
```

- Fix Insecure Source URI

  Use https instead of `github` option, use an insecure source could be subjected to MITM attack.

- Use released web-console 3.1.1

- **Security Updates:**

    - Fixed: [devise](https://github.com/plataformatec/devise), [3.5.3...4.0.0.pre.dev](https://github.com/plataformatec/devise/compare/a321282ccc93d73f9d0f7a1319d3fcab27d25b20...b97b3e6e3b570324467ac84d807111837943ec20) ([CHANGELOG](https://github.com/plataformatec/devise/blob/master/CHANGELOG.md))
      * http://rubysec.com/advisories/CVE-2015-8314
    - Fixed: [nokogiri](https://github.com/sparklemotion/nokogiri), [1.6.7.1...1.6.7.2](https://github.com/sparklemotion/nokogiri/compare/v1.6.7.1...v1.6.7.2) ([CHANGELOG](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.ja.rdoc))
      * http://rubysec.com/advisories/CVE-2015-7499

--

By the way,
I ran this repo with a free service called https://www.deppbot.com to find out about this, see the [Pull Request issued by deppbot](https://github.com/JuanitoFatas/codetriage/pull/1). :blush:  