### PR TITLE
Order all_languages alphabetically

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -67,7 +67,7 @@ class Repo < ActiveRecord::Base
   end
 
   def self.all_languages
-    self.select("language").group("language").map(&:language).reject(&:blank?)
+    self.select("language").group("language").order("language ASC").map(&:language).reject(&:blank?)
   end
 
   def self.repos_needing_help_for_user(user)


### PR DESCRIPTION
Ordering all languages alphabetically makes finding your favorite languages in the preferences much easier, before:

![screen shot 2016-01-28 at 6 38 08 pm](https://cloud.githubusercontent.com/assets/1060/12655353/78e47292-c5f0-11e5-959b-a9c66c29b4ba.png)

After:

![screen shot 2016-01-28 at 6 52 31 pm](https://cloud.githubusercontent.com/assets/1060/12655359/7e11ddb8-c5f0-11e5-848e-ac43b438ac74.png)
