### PR TITLE
Add Rails master to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: ruby
 sudo: false
 rvm:
   - 2.3.0
+env:
+  matrix:
+    - "RAILS_MASTER=0"
+    - "RAILS_MASTER=1"
+before_install:
+  - bundle install
 script:
   - RAILS_ENV=test bin/rake test
 before_script:
@@ -17,5 +23,8 @@ deploy:
   on:
     repo: codetriage/codetriage
   run: "bin/rake db:migrate"
+matrix:
+  allow_failures:
+    - env: "RAILS_MASTER=1"
 cache:
   - bundler

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,11 @@ ruby '2.3.0'
 gem 'mime-types', '~> 2.6.1', require: 'mime/types/columnar'
 
 # Gems required in all environments
-gem 'rails', '5.0.0.beta2'
+if ENV["RAILS_MASTER"] == '1'
+  gem 'rails', git: 'https://github.com/rails/rails.git'
+else
+  gem 'rails', '5.0.0.beta2'
+end
 
 gem 'puma'
 gem 'puma_auto_tune'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,6 @@ GEM
     activesupport (5.0.0.beta2)
       concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      method_source
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)


### PR DESCRIPTION
This will allow Rails to have better integration testing on existing,
and production-running apps. As well, the `RAILS_MASTER=1` build is in
the allowed failure category, so it will not disrupt the normal CI
procedure for Code Triage.

\c @schneems 