### PR TITLE
Explicitly disable caching for Pages#index

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
+  before_action :set_cache_headers, only: [:index]
+
   def index
     @repos = Repo.with_some_issues
     if language = valid_params[:language] || current_user.try(:favorite_languages)
@@ -22,4 +24,12 @@ class PagesController < ApplicationController
   def valid_params
     params.permit(:language, :per_page, :page)
   end
+
+  private
+
+    def set_cache_headers
+      response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    end
 end

--- a/test/functional/pages_controller_test.rb
+++ b/test/functional/pages_controller_test.rb
@@ -19,4 +19,11 @@ class PagesControllerTest < ActionController::TestCase
     get :index
     assert_nil assigns(:repos_subs), 'not assigns to repos_subs'
   end
+
+  test "cache control for headers" do
+    get :index
+    assert_equal("no-cache, no-store, max-age=0, must-revalidate", @response.headers["Cache-Control"])
+    assert_equal("no-cache", @response.headers["Pragma"])
+    assert_equal("Fri, 01 Jan 1990 00:00:00 GMT", @response.headers["Expires"])
+  end
 end


### PR DESCRIPTION
@schneems 
This should resolve #437.

I have added headers to the response of the index action in the
  pages controller which prohibits the browser from caching the page.

A new test in `pages_controller_test.rb` has also been added.

Tested with Chrome on OS X