### PR TITLE
Reset to First Page on Language Switch

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -50,6 +50,7 @@ javascript:
         var language = this.getAttribute("data-language");
         $(".types-filter-button").html(language);
         updateQueryStringParam("language", language);
+        removeQueryStringParam("page");
 
         $.ajax({
           url: document.URL,
@@ -69,8 +70,22 @@ javascript:
         return false;
       });
 
+    function baseUrl() {
+      return [location.protocol, '//', location.host, location.pathname].join('');
+    }
+
+    function removeQueryStringParam(param) {
+      var urlQueryString = document.location.search;
+
+      if (urlQueryString) {
+        keyRegex = new RegExp('&?' + param + '[^&]*');
+        params = urlQueryString.replace(keyRegex, '');
+      }
+
+      window.history.replaceState({}, '', baseUrl() + params);
+    }
+
     function updateQueryStringParam(param, value) {
-      baseUrl = [location.protocol, '//', location.host, location.pathname].join('');
       urlQueryString = document.location.search;
       var newParam = param + '=' + encodeURIComponent(value),
       params = '?' + newParam;
@@ -85,7 +100,7 @@ javascript:
           params = urlQueryString + '&' + newParam;
         }
       }
-      window.history.replaceState({}, "", baseUrl + params);
+      window.history.replaceState({}, "", baseUrl() + params);
     };
   });
 


### PR DESCRIPTION
This Resolves #429

When paginating and then changing languages, the `page` URL parameter persisted.

It seems that it would be better to reset to the first page when moving between
  languages to prevent the following behaviour:

1. Language "A" has > 10 pages
2. Language "B" has < 10 pages
3. User on Page 12 of language "A" selects language "B"
4. User is shown empty page of language "B" results since language "B" results
   can not fill 12 pages

This code simply extends the existing javascript solution.