### PR TITLE
ENV is hash not an array

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,7 @@ require 'sidekiq/web'
 
 CodeTriage::Application.routes.draw do
 
-
-  ENV.each do |var|
+  ENV.each do |var, _|
     next unless var.starts_with?("ACME_TOKEN_")
     value = var.split('_')[2..-1]
     get ".well-known/acme-challenge/#{ ENV["ACME_TOKEN_#{value}"] }" => proc { [200, {}, [ ENV["ACME_KEY_#{value}"] ] ] }


### PR DESCRIPTION
Fixes following error 

```
/Users/prathamesh/Projects/sources/codetriage/config/routes.rb:6:in `block (2 levels) in <top (required)>': undefined method `starts_with?' for ["RBENV_VERSION", "2.3.0"]:Array (NoMethodError)
	from /Users/prathamesh/Projects/sources/codetriage/config/routes.rb:5:in `each'
	from /Users/prathamesh/Projects/sources/codetriage/config/routes.rb:5:in `block in <top (required)>'
```

cc @schneems 