### PR TITLE
Fix 404 error when anonymous user tries to triage a repo

### DIFF
--- a/app/helpers/repos_helper.rb
+++ b/app/helpers/repos_helper.rb
@@ -1,6 +1,6 @@
 module ReposHelper
   def wanna_triage_button(repo, html_class: "")
-    path = user_signed_in? ? repo_subscriptions_path(repo_id: repo.id) : user_omniauth_authorize_path(:github)
+    path = user_signed_in? ? repo_subscriptions_path(repo_id: repo.id) : user_omniauth_authorize_path(:github, origin: request.fullpath)
     button_to "I Want to Triage #{repo.path}", path, class: "button #{html_class}"
   end
 end

--- a/app/helpers/repos_helper.rb
+++ b/app/helpers/repos_helper.rb
@@ -1,0 +1,6 @@
+module ReposHelper
+  def wanna_triage_button(repo, html_class: "")
+    path = user_signed_in? ? repo_subscriptions_path(repo_id: repo.id) : user_omniauth_authorize_path(:github)
+    button_to "I Want to Triage #{repo.path}", path, class: "button #{html_class}"
+  end
+end

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -13,8 +13,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
         p.repo-instructions
           | When you volunteer to triage issues, you'll receive an email each day with a link to an open issue that needs to be triaged in this project.
             You'll also receive instructions on how to triage issues.
-
-        = button_to "I Want to Triage #{@repo.path}", repo_subscriptions_path(repo_id: @repo.id), class: 'button repo-action'
+        = wanna_triage_button(@repo, html_class: "repo-action")
       - else
         h2.content-section-title Currently receiving #{@repo_sub.email_limit} issues per day.
         .repo-instructions
@@ -60,4 +59,4 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           | Stop Triaging
 
     - if @repo_sub.blank?
-      = button_to "I Want to Triage #{@repo.path}", repo_subscriptions_path(repo_id: @repo.id), class: 'button full-width-action'
+      = wanna_triage_button(@repo, html_class: "full-width-action")


### PR DESCRIPTION
As @schneems suggested in #434 I've changed "I want to triage..." button behavior. 

When user is not signed the button redirects to authorization page and then user is redirected to the repository page. The user must click the button once again, but there is no 404 error page.

Behavior for logged user remains the same.