### PR TITLE
Repo#find_by_full_name triggers memory bloat w/ :issues include

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -170,7 +170,7 @@ class Repo < ActiveRecord::Base
   end
 
   def self.find_by_full_name(full_name)
-    Repo.includes(:issues).find_by!(full_name: full_name)
+    Repo.find_by!(full_name: full_name)
   end
 
   private


### PR DESCRIPTION
It appears that `Repo#find_by_full_name` triggers some memory bloat when called by repos with many issues:

<img width="898" alt="reposcontroller_show" src="https://cloud.githubusercontent.com/assets/7880/15306738/7b7829b4-1b8a-11e6-817b-b423e8ddd825.png">

I believe the offender is the `includes(:issues)`, which thankfully, [I don't believe is used by any of the callers](https://github.com/codetriage/codetriage/search?utf8=%E2%9C%93&q=find_repo&type=Code).

Here's a massive one-line PR to address this.

