### PR TITLE
Refine user selectable email frequency

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -26,7 +26,7 @@ label {
 }
 
 #{$all-text-inputs},
-select[multiple=multiple] {
+select{
   background-color: $base-background-color;
   border: $base-border;
   box-sizing: border-box;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,6 +62,7 @@ class UsersController < ApplicationController
         :avatar_url,
         :name,
         :daily_issue_limit,
+        :email_frequency,
         :skip_issues_with_pr,
         favorite_languages: []
         )

--- a/app/models/email_decider.rb
+++ b/app/models/email_decider.rb
@@ -3,10 +3,11 @@
 # last day we sent them an email. The idea is that we should send more active users
 # more emails. Less active users should get fewer emails so that it's less annoying.
 class EmailDecider
+  USER_STATES = ["daily", "twice_a_week", "once_a_week", "once_a_month"]
 
-  def initialize(last_clicked_days_ago, user_frequency="")
+  def initialize(last_clicked_days_ago, minimum_frequency: nil)
     @last_clicked_days_ago = last_clicked_days_ago
-    @user_frequency = user_frequency
+    @minimum_frequency     = minimum_frequency
   end
 
   def skip?(last_sent_days_ago)
@@ -16,16 +17,16 @@ class EmailDecider
   # send an email if you've clicked one in the last 3 days
   # back down to twice a week if they've not clicked in the last 7
   def now?(last_sent_days_ago)
-    case user_frequency_or_calculated_frequency
-    when :daily
+    case minimum_calculated_frequency
+    when "daily"
       true
-    when :once_a_week
-      last_sent_days_ago.modulo(7).zero?
-    when :twice_a_week
+    when "twice_a_week"
       last_sent_days_ago.modulo(3).zero?
-    when :once_a_month
+    when "once_a_week"
+      last_sent_days_ago.modulo(7).zero?
+    when "once_a_month"
       last_sent_days_ago.modulo(30).zero?
-    when :wait
+    when "wait"
       false
     else
       raise "Unknown case: #{frequency}"
@@ -33,22 +34,34 @@ class EmailDecider
   end
 
   private
-    def user_frequency_or_calculated_frequency
-      @user_frequency.present? ? @user_frequency.to_sym : frequency_of_send_rate
+    # When a user provides a default frequency use that value
+    # For instance if a user has "twice_a_week" selected as a default yet we calculate their
+    # send rate as "daily" the higher value will be used i.e. "twice_a_week". If however
+    # they are inactive and calculated frequency is "once_a_month" we will use that instead.
+    # The highest duration wins between user supplied and calculated
+    def minimum_calculated_frequency
+      return frequency_of_send_rate if @minimum_frequency.blank?
+      return frequency_of_send_rate if !USER_STATES.include?(frequency_of_send_rate)
+
+      if USER_STATES.index(@minimum_frequency) > USER_STATES.index(frequency_of_send_rate)
+        @minimum_frequency
+      else
+        frequency_of_send_rate
+      end
     end
 
     def frequency_of_send_rate
       case @last_clicked_days_ago
       when 0..3
-        :daily
+        "daily"
       when 7..13
-        :twice_a_week
+        "twice_a_week"
       when 14..30
-        :once_a_week
+        "once_a_week"
       when 31..Float::INFINITY
-        :once_a_month
+        "once_a_month"
       else
-        :wait
+        "wait"
       end
     end
 end

--- a/app/models/email_decider.rb
+++ b/app/models/email_decider.rb
@@ -4,8 +4,9 @@
 # more emails. Less active users should get fewer emails so that it's less annoying.
 class EmailDecider
 
-  def initialize(last_clicked_days_ago)
+  def initialize(last_clicked_days_ago, user_frequency="")
     @last_clicked_days_ago = last_clicked_days_ago
+    @user_frequency = user_frequency
   end
 
   def skip?(last_sent_days_ago)
@@ -15,7 +16,7 @@ class EmailDecider
   # send an email if you've clicked one in the last 3 days
   # back down to twice a week if they've not clicked in the last 7
   def now?(last_sent_days_ago)
-    case frequency_of_send_rate
+    case user_frequency_or_calculated_frequency
     when :daily
       true
     when :once_a_week
@@ -32,6 +33,10 @@ class EmailDecider
   end
 
   private
+    def user_frequency_or_calculated_frequency
+      @user_frequency.present? ? @user_frequency.to_sym : frequency_of_send_rate
+    end
+
     def frequency_of_send_rate
       case @last_clicked_days_ago
       when 0..3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,7 +129,7 @@ class User < ActiveRecord::Base
 
   def send_daily_triage!
     return false if repo_subscriptions.blank?
-    skip = EmailDecider.new(days_since_last_clicked).skip?(days_since_last_email)
+    skip = EmailDecider.new(days_since_last_clicked, email_frequency).skip?(days_since_last_email)
     puts "User #{github}: skip: #{skip.inspect}, days_since_last_clicked: #{days_since_last_clicked}, days_since_last_email: #{days_since_last_email}"
     return false if skip
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
   validates_uniqueness_of :email,    allow_blank: true, if: :email_changed?
   validates_length_of     :password, within:  8..128, allow_blank: true
   validates :github, presence: true, uniqueness: true
+  validates :email_frequency, inclusion: { in: EmailDecider::USER_STATES.map(&:to_s) , message: "Not a valid frequency, pick from #{ EmailDecider::USER_STATES }" }
 
   # Setup accessible (or protected) attributes for your model
 
@@ -129,7 +130,7 @@ class User < ActiveRecord::Base
 
   def send_daily_triage!
     return false if repo_subscriptions.blank?
-    skip = EmailDecider.new(days_since_last_clicked, email_frequency).skip?(days_since_last_email)
+    skip = EmailDecider.new(days_since_last_clicked, minimum_frequency: email_frequency).skip?(days_since_last_email)
     puts "User #{github}: skip: #{skip.inspect}, days_since_last_clicked: #{days_since_last_clicked}, days_since_last_email: #{days_since_last_email}"
     return false if skip
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -5,6 +5,12 @@
       span.add-on
         i.icon-envelope
       = f.text_field :email, class: 'text_field'
+  = f.label :email_frequency, t("activerecord.attributes.user.email_frequency", default: "Email Frequency"), class: "label label-info"
+  .controld
+    .input-preprend
+      span.add-on
+        i.icon-envelope
+      = f.select :email_frequency, options_for_select([ ["Daily", "daily"], ["Once a week", "once_a_week"], ["Twice a week", "twice_a_week"], ["Once a month", "once_a_month"] ]), class: 'select'
   = f.label :daily_issue_limit, t("activerecord.attributes.user.daily_issue_limit", default: "Max # of issues you want to receive per day"), class: "label label-info"
   .input
     = f.number_field :daily_issue_limit, class: 'number_field', min: 0

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -10,11 +10,15 @@
     .input-preprend
       span.add-on
         i.icon-envelope
-      = f.select :email_frequency, options_for_select([ ["Daily", "daily"], ["Once a week", "once_a_week"], ["Twice a week", "twice_a_week"], ["Once a month", "once_a_month"] ]), class: 'select'
+      = f.select :email_frequency, options_for_select( EmailDecider::USER_STATES.map {|value| [ value.humanize, value ] } ), class: 'select'
+      p When you're busy we try to send you less emails, if that's not good enough set your frequency here. For example if you set "twice a week" you won't receive more than 2 emails a week.
   = f.label :daily_issue_limit, t("activerecord.attributes.user.daily_issue_limit", default: "Max # of issues you want to receive per day"), class: "label label-info"
   .input
     = f.number_field :daily_issue_limit, class: 'number_field', min: 0
+    p If you're getting too many issues, limit the maximum number you want to get in your inbox at one time. To disable submit an empty value.
   = f.check_box :skip_issues_with_pr, class: 'checkbox'
-  => f.label :skip_issues_with_pr, t("activerecord.attributes.user.skip_issues_with_pr", default: "Skip Issues with Pull requests"), class: "label label-info"
+  => f.label :skip_issues_with_pr, t("activerecord.attributes.user.skip_issues_with_pr", default: "Skip Pull requests"), class: "label label-info"
+  p By default we send you a combination of issues and pull request, check this box to only get Issues.
+
 .form-actions
   => button_tag "Save", class: "button full-width-action"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -28,6 +28,11 @@
               - else
                 | Private,
                 = link_to "Go public", user_registration_path(user: {private: false}), method: :patch
+        li.slats-item
+          .slats-hgroup
+            h5.slats-title Email frequency:
+          .slats-action
+            p= @user.email_frequency.presence || 'not set'
 
         li.slats-item
           .slats-hgroup

--- a/db/migrate/20160606060546_add_email_frequency_to_users.rb
+++ b/db/migrate/20160606060546_add_email_frequency_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailFrequencyToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :email_frequency, :string
+  end
+end

--- a/db/migrate/20160606060546_add_email_frequency_to_users.rb
+++ b/db/migrate/20160606060546_add_email_frequency_to_users.rb
@@ -1,5 +1,5 @@
 class AddEmailFrequencyToUsers < ActiveRecord::Migration[5.0]
   def change
-    add_column :users, :email_frequency, :string
+    add_column :users, :email_frequency, :string, default: "daily"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160404173429) do
+ActiveRecord::Schema.define(version: 20160606060546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,10 +31,9 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "clicked",              default: false
+    t.index ["repo_id"], name: "index_doc_assignments_on_repo_id", using: :btree
+    t.index ["repo_subscription_id"], name: "index_doc_assignments_on_repo_subscription_id", using: :btree
   end
-
-  add_index "doc_assignments", ["repo_id"], name: "index_doc_assignments_on_repo_id", using: :btree
-  add_index "doc_assignments", ["repo_subscription_id"], name: "index_doc_assignments_on_repo_subscription_id", using: :btree
 
   create_table "doc_classes", force: :cascade do |t|
     t.integer  "repo_id"
@@ -45,9 +44,8 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.integer  "line"
     t.string   "path"
     t.string   "file"
+    t.index ["repo_id"], name: "index_doc_classes_on_repo_id", using: :btree
   end
-
-  add_index "doc_classes", ["repo_id"], name: "index_doc_classes_on_repo_id", using: :btree
 
   create_table "doc_comments", force: :cascade do |t|
     t.integer  "doc_class_id"
@@ -55,10 +53,9 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.text     "comment"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["doc_class_id"], name: "index_doc_comments_on_doc_class_id", using: :btree
+    t.index ["doc_method_id"], name: "index_doc_comments_on_doc_method_id", using: :btree
   end
-
-  add_index "doc_comments", ["doc_class_id"], name: "index_doc_comments_on_doc_class_id", using: :btree
-  add_index "doc_comments", ["doc_method_id"], name: "index_doc_comments_on_doc_method_id", using: :btree
 
   create_table "doc_methods", force: :cascade do |t|
     t.integer  "repo_id"
@@ -72,9 +69,8 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.boolean  "skip_write",         default: false
     t.boolean  "active",             default: true
     t.boolean  "skip_read",          default: false
+    t.index ["repo_id"], name: "index_doc_methods_on_repo_id", using: :btree
   end
-
-  add_index "doc_methods", ["repo_id"], name: "index_doc_methods_on_repo_id", using: :btree
 
   create_table "issue_assignments", force: :cascade do |t|
     t.integer  "issue_id"
@@ -83,9 +79,8 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.integer  "repo_subscription_id"
     t.boolean  "clicked",              default: false
     t.boolean  "delivered",            default: false
+    t.index ["delivered"], name: "index_issue_assignments_on_delivered", using: :btree
   end
-
-  add_index "issue_assignments", ["delivered"], name: "index_issue_assignments_on_delivered", using: :btree
 
   create_table "issues", force: :cascade do |t|
     t.integer  "comment_count"
@@ -101,11 +96,10 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.string   "html_url",        limit: 255
     t.string   "state",           limit: 255
     t.boolean  "pr_attached",                 default: false
+    t.index ["number"], name: "index_issues_on_number", using: :btree
+    t.index ["repo_id"], name: "index_issues_on_repo_id", using: :btree
+    t.index ["state"], name: "index_issues_on_state", using: :btree
   end
-
-  add_index "issues", ["number"], name: "index_issues_on_number", using: :btree
-  add_index "issues", ["repo_id"], name: "index_issues_on_repo_id", using: :btree
-  add_index "issues", ["state"], name: "index_issues_on_state", using: :btree
 
   create_table "opro_auth_grants", force: :cascade do |t|
     t.string   "code",                    limit: 255
@@ -183,11 +177,11 @@ ActiveRecord::Schema.define(version: 20160404173429) do
     t.boolean  "skip_issues_with_pr",                default: false
     t.string   "account_delete_token",   limit: 255
     t.datetime "last_clicked_at"
+    t.string   "email_frequency"
+    t.index ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree
+    t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
+    t.index ["github"], name: "index_users_on_github", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
-
-  add_index "users", ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["github"], name: "index_users_on_github", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -177,7 +177,7 @@ ActiveRecord::Schema.define(version: 20160606060546) do
     t.boolean  "skip_issues_with_pr",                default: false
     t.string   "account_delete_token",   limit: 255
     t.datetime "last_clicked_at"
-    t.string   "email_frequency"
+    t.string   "email_frequency",                    default: "daily"
     t.index ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["github"], name: "index_users_on_github", unique: true, using: :btree

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -22,6 +22,7 @@ mockstar:
   favorite_languages: [ "ruby" ]
   last_clicked_at: <%= Time.now %>
   avatar_url: http://gravatar.com/avatar/default
+  email_frequency: daily
 
 schneems:
   email: richard.schneeman@gmail.com
@@ -46,6 +47,7 @@ schneems:
   private: false
   last_clicked_at: <%= Time.now %>
   avatar_url: http://gravatar.com/avatar/default
+  email_frequency: daily
 
 jroes:
   email: jroes@jroes.net
@@ -70,6 +72,7 @@ jroes:
   private: true
   last_clicked_at: <%= Time.now %>
   avatar_url: http://gravatar.com/avatar/default
+  email_frequency: daily
 
 empty:
   email: empty@empty.com
@@ -94,3 +97,4 @@ empty:
   private: false
   last_clicked_at: <%= Time.now %>
   avatar_url: http://gravatar.com/avatar/default
+  email_frequency: daily

--- a/test/unit/email_decider_test.rb
+++ b/test/unit/email_decider_test.rb
@@ -12,6 +12,8 @@ class EmailDeciderTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     assert EmailDecider.new(day_ago).now?(clicked_ago), "Expected  EmailDecider.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
+    # Use user email frequency settings
+    refute EmailDecider.new(day_ago, "once_a_week").now?(clicked_ago), "Expected  EmailDecider.new(#{day_ago}, 'once_a_week').now?(#{clicked_ago}) to be false, was not"
 
     # wait
     last_clicked_days_ago = 4..6

--- a/test/unit/email_decider_test.rb
+++ b/test/unit/email_decider_test.rb
@@ -13,7 +13,7 @@ class EmailDeciderTest < ActiveSupport::TestCase
     clicked_ago           = valid_values.sample
     assert EmailDecider.new(day_ago).now?(clicked_ago), "Expected  EmailDecider.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
     # Use user email frequency settings
-    refute EmailDecider.new(day_ago, "once_a_week").now?(clicked_ago), "Expected  EmailDecider.new(#{day_ago}, 'once_a_week').now?(#{clicked_ago}) to be false, was not"
+    refute EmailDecider.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago), "Expected  EmailDecider.new(#{day_ago}, 'once_a_week').now?(#{clicked_ago}) to be false, was not"
 
     # wait
     last_clicked_days_ago = 4..6


### PR DESCRIPTION
We don't want a user setting a "default" value to short circuit our deciding logic. We still want to back off if they're not interacting so they don't get burned out and turn off  emails. 

This PR includes commit from #472
