### PR TITLE
Avoid all the warnings we can

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
       sass (~> 3.4)
       sprockets (~> 4.x)
       sprockets-rails (< 4.0)
-    scout_apm (2.0.0.pre)
+    scout_apm (2.0.0.pre3)
       rusage (~> 0.2.0)
     sidekiq (4.0.2)
       concurrent-ruby (~> 1.0)

--- a/config/initializers/git_hub_bub.rb
+++ b/config/initializers/git_hub_bub.rb
@@ -1,7 +1,11 @@
+# I know it's awful but I don't have time to fix the GitHubBub API and this makes `rails c` not noisey
+GitHubBub::Request.send(:remove_const, :GITHUB_VERSION)
+GitHubBub::Request.send(:remove_const, :USER_AGENT)
+GitHubBub::Request.send(:remove_const, :RETRIES)
 
-GitHubBub::Request::USER_AGENT = 'codetriage'
-GitHubBub::Request::RETRIES    = 3
-GitHubBub::Request::GITHUB_VERSION = "vnd.github.v3.full+json"
+GitHubBub::Request::GITHUB_VERSION = 'vnd.github.v3.full+json'
+GitHubBub::Request::USER_AGENT     ='codetriage'
+GitHubBub::Request::RETRIES        = 3
 
 # Auth all non authed requests (due to github request limits)
 GitHubBub::Request.set_before_callback do |request|

--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -1,0 +1,11 @@
+defaults: &defaults
+  name: codetriage
+  key: <%= ENV['SCOUT_KEY'] %>
+  monitor: <%= true if ENV['SCOUT_MONITOR'] %>
+
+development:
+  <<: *defaults
+test:
+  <<: *defaults
+production:
+  <<: *defaults


### PR DESCRIPTION
There is still a warning from scout_apm telling us that things are working fine. I opened an issue https://github.com/scoutapp/scout_apm_ruby/issues/49