### PR TITLE
Ensure select text colour is black

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -89,4 +89,5 @@ select {
   max-width: 100%;
   width: auto;
   background-color: white;
+  color: black;
 }

--- a/app/assets/stylesheets/components/_repo.scss
+++ b/app/assets/stylesheets/components/_repo.scss
@@ -54,7 +54,6 @@
 
   select {
     display: inline-block;
-    color: black;
   }
 
   .save-amount {


### PR DESCRIPTION
This PR adds a css styling across all select boxes to ensure black text colour.

With this PR issue #494 can be closed, and I believe #432 as well.

Select value already defaults to "daily", as mentioned on #494, so nothing else had to be done.

