### PR TITLE
Enable separate doc registration #482

### DIFF
--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -5,7 +5,7 @@ class RepoSubscription < ActiveRecord::Base
 
   validates  :repo_id, uniqueness: { scope: :user_id }, presence: true
   validates  :user_id, presence: true
-  validates  :email_limit, numericality: { less_than: 21, greater_than: 0 }
+  validates  :email_limit, numericality: { less_than: 21, greater_than_or_equal_to: 0 }
 
   belongs_to :repo
   belongs_to :user

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -22,14 +22,12 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           = form_for(@repo_sub, html: { class: 'email-amount'} ) do |f|
             label Triage more issues! (Or less)
             => f.select :email_limit, (0..20)
-            = f.submit "Save", class: 'save-amount'
-            
+            = f.submit "Save", class: 'save-amount'            
         - if (@repo_sub.email_limit > 0)
           = link_to issue_assignments_path(id: @repo_sub.id), class: 'button repo-action', method: :post do
             | Send me a new issue!
 
-    section.help-triage.content-section
-      
+    section.help-triage.content-section  
       - if @repo_sub.blank? || (@repo_sub.write.blank? && @repo_sub.read.blank?)
         h2.content-section-title Triage Docs!
         p.repo-instructions

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -21,14 +21,17 @@ div class="subpage-content-wrapper #{ @repo.weight }"
         .repo-instructions
           = form_for(@repo_sub, html: { class: 'email-amount'} ) do |f|
             label Triage more issues! (Or less)
-            => f.select :email_limit, (1..20)
+            => f.select :email_limit, (0..20)
             = f.submit "Save", class: 'save-amount'
-        = link_to issue_assignments_path(id: @repo_sub.id), class: 'button repo-action', method: :post do
-          | Send me a new issue!
+            
+        - if (@repo_sub.email_limit > 0)
+          = link_to issue_assignments_path(id: @repo_sub.id), class: 'button repo-action', method: :post do
+            | Send me a new issue!
 
     section.help-triage.content-section
-      h2.content-section-title Triage Docs!
+      
       - if @repo_sub.blank? || (@repo_sub.write.blank? && @repo_sub.read.blank?)
+        h2.content-section-title Triage Docs!
         p.repo-instructions
           | Receive a documented method or class from your favorite GitHub repos in your inbox every day. If you're really pro, receive undocumented methods or classes and supercharge your commit history.
         - if @repo.can_doctor_docs?
@@ -37,6 +40,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           = link_to "#{@repo.language} not yet supported", '#', class: "button inactive repo-action"
 
       - else
+          h2.content-section-title Currently receiving #{@repo_sub.write_limit + @repo_sub.read_limit} docs per day.
           .repo-instructions
             = form_for(@repo_sub, html: {class: 'email-amount'}) do |f|
               label Triage more docs! (Or less)

--- a/test/functional/repo_subscriptions_controller_test.rb
+++ b/test/functional/repo_subscriptions_controller_test.rb
@@ -58,7 +58,7 @@ class RepoSubscriptionsControllerTest < ActionController::TestCase
     repo_subscription = repo_subscriptions(:schneems_to_triage)
     sign_in users(:schneems)
     patch :update, params: { id: repo_subscription.id,
-                             repo_subscription: { email_limit: 0 } }
+                             repo_subscription: { email_limit: -1 } }
     assert_equal flash[:error], "Something went wrong"
     assert_redirected_to repo_path(repo_subscription.repo)
   end


### PR DESCRIPTION
#482 

Fixes bug where users must select issues to triage before selecting docs, and incorporates minor view tweaks to standardize the two. 