### PR TITLE
RepoBasedController#find_repo: Automatically Update Repository If updated_at Is Over 6 Hours Ago

### DIFF
--- a/app/controllers/repo_based_controller.rb
+++ b/app/controllers/repo_based_controller.rb
@@ -1,11 +1,11 @@
 class RepoBasedController < ApplicationController
-  protected
+	protected
 
-    def name_from_params(options)
-      [options[:name], options[:format]].compact.join('.')
-    end
+	def name_from_params(options)
+		[options[:name], options[:format]].compact.join('.')
+	end
 
-    def find_repo(options)
-      Repo.find_by_full_name(options[:full_name])
-    end
+	def find_repo(options)
+		Repo.find_by_full_name(options[:full_name])
+	end
 end

--- a/app/controllers/repo_based_controller.rb
+++ b/app/controllers/repo_based_controller.rb
@@ -1,11 +1,15 @@
 class RepoBasedController < ApplicationController
-	protected
+  protected
 
-	def name_from_params(options)
-		[options[:name], options[:format]].compact.join('.')
-	end
+  def name_from_params(options)
+    [options[:name], options[:format]].compact.join('.')
+  end
 
-	def find_repo(options)
-		Repo.find_by_full_name(options[:full_name])
-	end
+  def find_repo(options)
+    if repo = Repo.find_by_full_name(options[:full_name])
+      repo.update_repo_info! if repo.updated_at < (Time.now - 6.hours)
+    end
+
+    repo
+  end
 end


### PR DESCRIPTION
The changes introduced will cause `RepoBasedController#find_repo` to check if the repository was updated over 6 hours ago, and queue an UpdateRepoInfoJob if so.  It returns the result of `Repo.find_by_full_name` either way, and only performs the check and job queuing if the result of this find is truthy.

I'm unsure about the performance drawbacks of this, since this check is performed every time a `RepoBasedController` uses the `#find_repo` method to locate a Repository.  I think this could also be split out into a separate method, and then the new method could be more appropriately used.

I'm willing to work on improvements to this as well.
