### PR TITLE
Improve layout of user settings content section

### DIFF
--- a/app/assets/stylesheets/components/_slats-list.scss
+++ b/app/assets/stylesheets/components/_slats-list.scss
@@ -54,7 +54,7 @@
     border-left: $content-border;
     float: right;
     margin: (-$small-spacing) (-$small-spacing) (-$small-spacing) 0;
-    min-width: 8rem;
+    min-width: 12rem;
   }
 
   p {


### PR DESCRIPTION
Before:
![screen shot 2016-09-07 at 9 13 08 pm](https://cloud.githubusercontent.com/assets/4067/18334881/872375d8-7540-11e6-8e9a-b898dc70c34b.png)

After:
![screen shot 2016-09-07 at 9 11 33 pm](https://cloud.githubusercontent.com/assets/4067/18334888/912f2536-7540-11e6-8114-32a8124c58c4.png)

Looks the same in Chrome and Safari.