### PR TITLE
Store labels in the db.

### DIFF
--- a/app/models/issue_label.rb
+++ b/app/models/issue_label.rb
@@ -1,0 +1,2 @@
+class IssueLabel < ActiveRecord::Base
+end

--- a/db/migrate/home/kevincox/p/codetriage/db/migrate/20160920211204_add_labels_for_issues.rb
+++ b/db/migrate/home/kevincox/p/codetriage/db/migrate/20160920211204_add_labels_for_issues.rb
@@ -1,0 +1,14 @@
+class AddLabelsForIssues < ActiveRecord::Migration[5.0]
+  def change
+    create_table :issue_labels, id: false, force: :cascade do |t|
+      t.integer :repo_id, null: false
+      t.integer :issue_id, null: false
+      t.text    :name, null: false
+    end
+
+    add_column :issues, :label_count, :integer
+
+    add_index :issue_labels, %w[issue_id], unique: true, using: :btree
+    add_index :issue_labels, %w[repo_id name issue_id], unique: true, using: :btree
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160827073041) do
+ActiveRecord::Schema.define(version: 20160920211204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,14 @@ ActiveRecord::Schema.define(version: 20160827073041) do
     t.index ["delivered"], name: "index_issue_assignments_on_delivered", using: :btree
   end
 
+  create_table "issue_labels", id: false, force: :cascade do |t|
+    t.integer "repo_id",  null: false
+    t.integer "issue_id", null: false
+    t.text    "name",     null: false
+    t.index ["issue_id"], name: "index_issue_labels_on_issue_id", unique: true, using: :btree
+    t.index ["repo_id", "name", "issue_id"], name: "index_issue_labels_on_repo_id_and_name_and_issue_id", unique: true, using: :btree
+  end
+
   create_table "issues", force: :cascade do |t|
     t.integer  "comment_count"
     t.string   "url"
@@ -95,6 +103,7 @@ ActiveRecord::Schema.define(version: 20160827073041) do
     t.string   "html_url"
     t.string   "state"
     t.boolean  "pr_attached",     default: false
+    t.integer  "label_count"
     t.index ["number"], name: "index_issues_on_number", using: :btree
     t.index ["repo_id"], name: "index_issues_on_repo_id", using: :btree
     t.index ["state"], name: "index_issues_on_state", using: :btree


### PR DESCRIPTION
The primary key of repo, label, issue will allow fast filtering of
issues matching a label in a repo.  This is the most email used for
sending emails.

This is progress towards #498 
