### PR TITLE
Added meta tags helper to render default or custom meta tags inside the helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,4 +29,10 @@ module ApplicationHelper
   def star_svg
     STAR_SVG
   end
+
+  # Render custom or default meta
+  # tags inside the header
+  def render_meta_tags
+    content_for?(:meta_tags) ? content_for(:meta_tags) : render('default_meta_tags'.freeze)
+  end
 end

--- a/app/views/application/_default_meta_tags.html.slim
+++ b/app/views/application/_default_meta_tags.html.slim
@@ -1,0 +1,2 @@
+meta name="name" content="CodeTriage"
+meta name="description" content="Help out your favorite open source projects and become a better developer while doing it"

--- a/app/views/application/_head.html.slim
+++ b/app/views/application/_head.html.slim
@@ -16,4 +16,6 @@ head
   <script src="//use.typekit.net/vyg4pus.js"></script>
   <script>try{Typekit.load({ async: true  });}catch(e){}</script>
 
+  = render_meta_tags
+
   = javascript_include_tag "application"


### PR DESCRIPTION
Added meta tags helper to render default or custom meta tags inside the helper. This fix will resolve issue#513.

Given default meta tags are:
Name: CodeTriage
Description: Help out your favorite open source projects and become a better developer while doing it

To render custom meta tags:
just use `content_for(:meta_tags)` block and define your meta tags. That's it!

This is how it shows to facebook:
![screen shot 2016-11-18 at 12 53 50 pm](https://cloud.githubusercontent.com/assets/417169/20421767/38c9a7ee-ad90-11e6-9b6b-7734e7f8d693.png)
