### PR TITLE
Ruby 2.4 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.3
+  - 2.4.0-rc1
+
 env:
   matrix:
     - "RAILS_MASTER=0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.3.3'
+ruby '> 2.3', '< 2.5'
 
 git_source :github do |name|
   "https://github.com/#{name}.git"
@@ -21,7 +21,6 @@ gem 'pg'
 gem 'omniauth', '1.3.1'
 gem 'omniauth-github'
 gem 'will_paginate', '3.1.0'
-gem 'httparty'
 gem 'dalli'
 gem 'wicked'
 gem 'rails_autolink'
@@ -93,8 +92,9 @@ gem 'babel-transpiler'
 gem 'scout_apm', '~> 2.0.x'
 gem 'yard'
 
-gem 'rollbar', '>= 2.13.2'
-gem 'oj', '~> 2.12.14'
+
+gem 'rollbar'
+gem 'oj'
 gem 'rack-canonical-host'
 
 gem 'stackprof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,7 +389,7 @@ DEPENDENCIES
   yard
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.4.0p-1
 
 BUNDLED WITH
    1.13.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,16 +132,13 @@ GEM
     hashie (3.4.3)
     heapy (0.1.2)
     hey_you (0.1.1)
-    httparty (0.13.7)
-      json (~> 1.8)
-      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jmespath (1.1.3)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.3)
+    json (2.0.2)
     jwt (1.5.1)
     kramdown (1.9.0)
     launchy (2.4.3)
@@ -183,7 +180,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (2.12.14)
+    oj (2.18.0)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -264,9 +261,9 @@ GEM
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       redis (~> 3.2, >= 3.2.1)
-    simplecov (0.10.0)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slim (3.0.7)
@@ -343,7 +340,6 @@ DEPENDENCIES
   dotenv-rails (= 2.1.0)
   foreman
   git_hub_bub
-  httparty
   jquery-rails
   launchy
   listen
@@ -354,7 +350,7 @@ DEPENDENCIES
   mocha
   neat
   normalize-rails
-  oj (~> 2.12.14)
+  oj
   omniauth (= 1.3.1)
   omniauth-github
   pg


### PR DESCRIPTION
Not sure why but `bundle install` does not update the `Gemfile.lock` to 2.4.