### PR TITLE
Bump coffee-rails and rollbar gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'bourbon'
 gem 'neat'
 gem 'autoprefixer-rails', '~> 6.3.3'
 gem 'normalize-rails'
-gem 'coffee-rails', '~> 4.1.0'
+gem 'coffee-rails', '~> 4.2.0'
 gem 'uglifier', '>= 1.0.3'
 gem 'slim-rails'
 
@@ -93,7 +93,7 @@ gem 'babel-transpiler'
 gem 'scout_apm', '~> 2.0.x'
 gem 'yard'
 
-gem 'rollbar'
+gem 'rollbar', '>= 2.13.2'
 gem 'oj', '~> 2.12.14'
 gem 'rack-canonical-host'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,13 +83,13 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    coffee-rails (4.1.1)
+    coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
+      railties (>= 4.0.0, < 5.2.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.10.0)
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
     crack (0.4.2)
@@ -167,7 +167,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     msgpack (1.0.0)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     neat (1.7.2)
@@ -248,7 +248,7 @@ GEM
     redis (3.2.2)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
-    rollbar (2.7.1)
+    rollbar (2.13.3)
       multi_json
     rrrretry (1.0.0)
     rusage (0.2.0)
@@ -336,7 +336,7 @@ DEPENDENCIES
   bourbon
   bullet (= 5.0.0)
   capybara (= 2.6.2)
-  coffee-rails (~> 4.1.0)
+  coffee-rails (~> 4.2.0)
   dalli
   derailed_benchmarks
   devise (= 4.0.0.rc1)
@@ -367,7 +367,7 @@ DEPENDENCIES
   rails_autolink
   rbtrace
   record_tag_helper (~> 1.0)
-  rollbar
+  rollbar (>= 2.13.2)
   rrrretry
   sassc
   sassc-rails!


### PR DESCRIPTION
These two gems are preventing CodeTriage from running CI against Rails
master. In the case of coffee-rails, it had a version restriction that
required the gem version being bumped. In the case of rollbar, the
version ahd to be bumped because the previous version has been using the
now removed `alias_method_chain`.