### PR TITLE
Add top border radius to repo item headers.

### DIFF
--- a/app/assets/stylesheets/components/_repo-list.scss
+++ b/app/assets/stylesheets/components/_repo-list.scss
@@ -71,6 +71,7 @@
 .repo-item-header {
   @include clearfix;
   background-color: $codetriage-blue;
+  border-radius: $base-border-radius $base-border-radius 0 0;
   margin: (-$base-spacing) (-$medium-spacing) $small-spacing;
   padding: $small-spacing $medium-spacing;
 


### PR DESCRIPTION
Hey there 👋

I noticed a small graphical bug while hovering over repo items. Attached is a gif showing the graphical glitch. When hovering over any `.repo-item`, all other `.repo-item`'s are affected.

![codetriage-glitch](https://cloud.githubusercontent.com/assets/171215/21940222/f38c9a22-d988-11e6-9964-d053a5850715.gif)

It seems that while hovering over a `.repo-item`, the corners of the `.repo-item-header` are showing for a split second. A simple solution is to round the top corners of the `.repo-item-header` to match the `.repo-item`.