### PR TITLE
Changes to schema.rb after rake db:migrate on clean setup

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,8 +73,8 @@ ActiveRecord::Schema.define(version: 20160927195642) do
 
   create_table "issue_assignments", force: :cascade do |t|
     t.integer  "issue_id"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_subscription_id"
     t.boolean  "clicked",              default: false
     t.boolean  "delivered",            default: false
@@ -84,48 +84,26 @@ ActiveRecord::Schema.define(version: 20160927195642) do
 
   create_table "issues", force: :cascade do |t|
     t.integer  "comment_count"
-    t.string   "url",             limit: 255
-    t.string   "repo_name",       limit: 255
-    t.string   "user_name",       limit: 255
+    t.string   "url"
+    t.string   "repo_name"
+    t.string   "user_name"
     t.datetime "last_touched_at"
     t.integer  "number"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "repo_id"
     t.text     "title"
-    t.string   "html_url",        limit: 255
-    t.string   "state",           limit: 255
-    t.boolean  "pr_attached",                 default: false
+    t.string   "html_url"
+    t.string   "state"
+    t.boolean  "pr_attached",     default: false
     t.index ["number"], name: "index_issues_on_number", using: :btree
     t.index ["repo_id"], name: "index_issues_on_repo_id", using: :btree
     t.index ["state"], name: "index_issues_on_state", using: :btree
   end
 
-  create_table "opro_auth_grants", force: :cascade do |t|
-    t.string   "code",                    limit: 255
-    t.string   "access_token",            limit: 255
-    t.string   "refresh_token",           limit: 255
-    t.text     "permissions"
-    t.datetime "access_token_expires_at"
-    t.integer  "user_id"
-    t.integer  "application_id"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-  end
-
-  create_table "opro_client_apps", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.string   "app_id",      limit: 255
-    t.string   "app_secret",  limit: 255
-    t.text     "permissions"
-    t.integer  "user_id"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
-
   create_table "repo_subscriptions", force: :cascade do |t|
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "user_id"
     t.integer  "repo_id"
     t.datetime "last_sent_at"
@@ -137,48 +115,48 @@ ActiveRecord::Schema.define(version: 20160927195642) do
   end
 
   create_table "repos", force: :cascade do |t|
-    t.string   "name",             limit: 255
-    t.string   "user_name",        limit: 255
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
-    t.integer  "issues_count",                 default: 0, null: false
-    t.string   "language",         limit: 255
-    t.string   "description",      limit: 255
-    t.string   "full_name",        limit: 255
+    t.string   "name"
+    t.string   "user_name"
+    t.integer  "issues_count",     default: 0, null: false
+    t.string   "language"
+    t.string   "description"
+    t.string   "full_name"
     t.text     "notes"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.text     "github_error_msg"
     t.string   "commit_sha"
-    t.integer  "stars_count",                  default: 0
+    t.integer  "stars_count",      default: 0
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  limit: 255, default: "",                                   null: false
-    t.string   "encrypted_password",     limit: 255, default: "",                                   null: false
-    t.string   "reset_password_token",   limit: 255
+    t.string   "email",                  default: "",                                   null: false
+    t.string   "encrypted_password",     default: "",                                   null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: 255
-    t.string   "last_sign_in_ip",        limit: 255
-    t.datetime "created_at",                                                                        null: false
-    t.datetime "updated_at",                                                                        null: false
-    t.string   "zip",                    limit: 255
-    t.string   "phone_number",           limit: 255
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string   "zip"
+    t.string   "phone_number"
     t.boolean  "twitter"
-    t.string   "github",                 limit: 255
-    t.string   "github_access_token",    limit: 255
+    t.string   "github"
+    t.string   "github_access_token"
     t.boolean  "admin"
-    t.string   "name",                   limit: 255
-    t.string   "avatar_url",             limit: 255, default: "http://gravatar.com/avatar/default"
-    t.boolean  "private",                            default: false
-    t.string   "favorite_languages",                                                                             array: true
+    t.string   "avatar_url",             default: "http://gravatar.com/avatar/default"
+    t.string   "name"
+    t.boolean  "private",                default: false
+    t.string   "favorite_languages",                                                                 array: true
     t.integer  "daily_issue_limit"
-    t.boolean  "skip_issues_with_pr",                default: false
-    t.string   "account_delete_token",   limit: 255
+    t.boolean  "skip_issues_with_pr",    default: false
+    t.string   "account_delete_token"
     t.datetime "last_clicked_at"
-    t.string   "email_frequency",                    default: "daily"
+    t.string   "email_frequency",        default: "daily"
     t.index ["account_delete_token"], name: "index_users_on_account_delete_token", using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["github"], name: "index_users_on_github", unique: true, using: :btree


### PR DESCRIPTION

I am setting up codetriage for development on my machine for the first time.
I have not had the databases or code before so I have a completely fresh environment.

I have followed the steps in the readme verbatim.
These are the changes to schema.rb that occured after running.
```
bin/rake db:create
bin/rake db:migrate
```

I have not investigated into the cause yet as I don't know much of the history.
I thought it would be of interest to you straight up as it seems a few tables, and defaults have been removed.

