### PR TITLE
Remove reference to docsdoctor.org in docs email

### DIFF
--- a/app/views/user_mailer/daily_docs.md.erb
+++ b/app/views/user_mailer/daily_docs.md.erb
@@ -33,6 +33,6 @@ Go forth and make the world a better place
 
 [@schneems](http://twitter.com/schneems)
 
-[Help doctor more docs at docsdoctor.org](<%= root_url%>)
+[Help doctor more docs at codetriage.com](<%= root_url%>)
 
 [Delete Account](<%= token_delete_user_url(@user.account_delete_token) %>)


### PR DESCRIPTION
Congratulations on the merging of docsdoctor.org into codetriage.com

This removes a small remnant. docsdoctor.org currently goes to a 'There's nothing here, yet.' Heroku page.
