### PR TITLE
Update readme to prefer `db:schema:load` over `db:migrate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ $ bundle install
 ```shell
 $ cp config/database.example.yml config/database.yml
 $ bin/rake db:create
-$ bin/rake db:migrate
-````
+$ bin/rake db:schema:load
+```
 
 ### Install Redis
 


### PR DESCRIPTION

Follow on from:
https://github.com/codetriage/codetriage/pull/526