### PR TITLE
Removed the trailing double quote mark present in the open file path in doc_methods show page in edit section of the page.

### DIFF
--- a/app/views/doc_methods/show.html.slim
+++ b/app/views/doc_methods/show.html.slim
@@ -29,7 +29,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
         |
           $ git clone git@github.com:#{ @doc.repo.full_name }.git
           $ cd #{ @doc.repo.name }
-          $ open #{ @doc.file }"
+          $ open #{ @doc.file }
     section.content-section
       h2.content-section-title Contribute
       pre


### PR DESCRIPTION
Fix for removing double quote from open path in edit section of docs methods

![codetriage open path issue](https://cloud.githubusercontent.com/assets/13130213/23688583/84925666-03db-11e7-82dd-7cbb399c1607.png)
