### PR TITLE
Check for `before_email_time_of_day?` first

### DIFF
--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -1,6 +1,6 @@
 class SendDailyTriageEmailJob < ApplicationJob
   def perform(user)
-    return false if !user.repo_subscriptions.any? || skip_daily_email?(user) || before_email_time_of_day?(user)
+    return false if before_email_time_of_day?(user) || !user.repo_subscriptions.any? || skip_daily_email?(user)
 
     send_daily_triage!(user)
   end


### PR DESCRIPTION
I think this check should be the cheapest.
If it returns true then the other queries do not need to run.