### PR TITLE
Fix sending duplicate emails

### DIFF
--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -1,6 +1,6 @@
 class SendDailyTriageEmailJob < ApplicationJob
   def perform(user)
-    return false if !user.repo_subscriptions.any? || skip_daily_email?(user) || before_email_time_of_day?(user)
+    return false if !user.repo_subscriptions.any? || email_sent_in_last_24_hours?(user) || skip_daily_email?(user) || before_email_time_of_day?(user)
 
     send_daily_triage!(user)
   end
@@ -17,6 +17,10 @@ class SendDailyTriageEmailJob < ApplicationJob
     assignments.update_all(delivered: true)
     user.repo_subscriptions.update_all(last_sent_at: Time.now)
     mail
+  end
+
+  def email_sent_in_last_24_hours?(user)
+    user.repo_subscriptions.where("last_sent_at >= ?", 24.hours.ago).any?
   end
 
   def skip_daily_email?(user)

--- a/test/jobs/send_daily_triage_email_job_test.rb
+++ b/test/jobs/send_daily_triage_email_job_test.rb
@@ -61,6 +61,16 @@ class SendDailyTriageEmailJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'when run multiple times a day, it does not deliver again' do
+    def @user.issue_assignments_to_deliver; IssueAssignment.all.limit(1); end
+    def @user.email_time_of_day; Time.utc(2000, 1, 1, 04, 0, 0); end
+
+    Time.stub(:now, time_preference_for_today(@user.email_time_of_day) + 1.hour) do
+      @job.perform(@user)
+      assert_not @job.perform(@user)
+    end
+  end
+
   private
 
   def time_preference_for_today(time)


### PR DESCRIPTION
This checks if any of user.repo_subscriptions has a last_sent_at that is set to within the last 24 hours. If that's the case then it will abort the job.