### PR TITLE
Add own app to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ public/assets
 
 # ignore vendor/bundle
 vendor/bundle
+tags

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ $ bin/rake db:schema:load RAILS_ENV=test
 
 You may need a github API token to run tests locally. You can get this by spinning your local server, clicking the "sign in" button and going through the OAuth flow.
 
+Note you may need to create your own app on GitHub for CodeTriage
+[here](https://github.com/settings/developers), and replace the values
+previously set (via the above) for `GITHUB_APP_ID` and `GITHUB_APP_SECRET` in
+order to complete the OAuth flow locally.
+
 Once you've done this spin down your server and run this:
 
 ```


### PR DESCRIPTION
It's quite possible I missed something (I see many forks, so seems odd I'd be the first to have this issue). But I was unable to OAuth locally without first creating my own app on GitHub (the default keys suggested above in the README resulted in an error). It's quite possible I misread the README, but I thought this might be helpful. Happy to make any other adjustments if this is useful.