### PR TITLE
Only show repos I own by default

### DIFF
--- a/app/views/repos/new.html.slim
+++ b/app/views/repos/new.html.slim
@@ -25,10 +25,10 @@
         .tab-pane.active#own
           = render 'shared/add_repos_list', repos: @own_repos
 
-        .tab-pane.active#starred
+        .tab-pane#starred
           = render 'shared/add_repos_list', repos: @starred_repos
 
-        .tab-pane.active#watched
+        .tab-pane#watched
           = render 'shared/add_repos_list', repos: @watched_repos
 
   section.content-section


### PR DESCRIPTION
The use of the `active` class on all 3 panes means that "owned",
"starred", and "watched" repos are all displayed, despite the fact that
the UI only has the "owned" tab as active. This is misleading/confusing.
While I think there's some benefit to an "all" option (scrolling is
easier than clicking) and therefore it's possible that this change
results in a decrease in repo added, I think it's worth the improved UX
(and the decreased metric can likely be remedied by ading and defaulting
to an "all repos" tab).

It appears this bug was introduced way back in
324c1a0358f18eba7ce75eee9fb2406baac25f9a when the feature to add starred
and watched repos was introduced.