### PR TITLE
Extract EmailFrequency Value Object

### DIFF
--- a/app/models/email_frequency.rb
+++ b/app/models/email_frequency.rb
@@ -1,0 +1,67 @@
+# Value Object representing the frequency with which email is sent. Used to
+#   compare two different frequencies, e.g. between a set value and calculated
+#   value.
+class EmailFrequency
+  include Comparable
+
+  # More frequent has a higher index, less frequent a lower index. The index is
+  #   used to compare the frequencies.
+  FREQUENCIES = [
+    WAIT         = "wait",
+    ONCE_A_MONTH = "once_a_month",
+    ONCE_A_WEEK  = "once_a_week",
+    TWICE_A_WEEK = "twice_a_week",
+    DAILY        = "daily"
+  ]
+
+  USER_FREQUENCIES = FREQUENCIES - [WAIT]
+
+  # Human-readable string representing the frequency; based on the constant
+  #   FREQUENCIES above.
+  attr_reader :frequency_description
+
+  def initialize(frequency_description)
+    raise ArgumentError unless frequency_description.in? FREQUENCIES
+    @frequency_description = frequency_description
+  end
+
+  # Constructor function that turns an int (num_days) into an EmailFrequency
+  def self.from_days(num_days)
+    case num_days
+    when 0..3
+      new(DAILY)
+    when 7..13
+      new(TWICE_A_WEEK)
+    when 14..30
+      new(ONCE_A_WEEK)
+    when 31..Float::INFINITY
+      new(ONCE_A_MONTH)
+    else
+      new(WAIT)
+    end
+  end
+
+  # With the Comparable module, this allows for `>` and `<` comparisons
+  def <=>(other)
+    FREQUENCIES.index(frequency_description) <=>
+      FREQUENCIES.index(other.frequency_description)
+  end
+
+  def eql?(other)
+    frequency_description == other.frequency_description
+  end
+
+  # Alias of `>`, used for easier code comprehension
+  def more_often?(other)
+    self > other
+  end
+
+  # Alias of `<`, used for easier code comprehension
+  def less_often?(other)
+    self < other
+  end
+
+  def to_s
+    frequency_description
+  end
+end

--- a/app/models/email_frequency.rb
+++ b/app/models/email_frequency.rb
@@ -52,16 +52,6 @@ class EmailFrequency
     frequency_description == other.frequency_description
   end
 
-  # Alias of `>`, used for easier code comprehension
-  def more_often?(other)
-    self > other
-  end
-
-  # Alias of `<`, used for easier code comprehension
-  def less_often?(other)
-    self < other
-  end
-
   def to_s
     frequency_description
   end

--- a/app/models/email_frequency.rb
+++ b/app/models/email_frequency.rb
@@ -7,6 +7,7 @@ class EmailFrequency
   # More frequent has a higher index, less frequent a lower index. The index is
   #   used to compare the frequencies.
   FREQUENCIES = [
+    # Wait is the _least_ frequent; used when a user has not yet clicked an email link, so we shouldn't send again (yet)
     WAIT         = "wait",
     ONCE_A_MONTH = "once_a_month",
     ONCE_A_WEEK  = "once_a_week",

--- a/app/models/email_rate_limit.rb
+++ b/app/models/email_rate_limit.rb
@@ -3,11 +3,9 @@
 # last day we sent them an email. The idea is that we should send more active users
 # more emails. Less active users should get fewer emails so that it's less annoying.
 class EmailRateLimit
-  USER_STATES = ["daily", "twice_a_week", "once_a_week", "once_a_month"]
-
-  def initialize(last_clicked_days_ago, minimum_frequency: nil)
-    @last_clicked_days_ago = last_clicked_days_ago
-    @minimum_frequency     = minimum_frequency
+  def initialize(last_clicked_days_ago, minimum_frequency: EmailFrequency::DAILY)
+    @frequency_from_last_click = EmailFrequency.from_days(last_clicked_days_ago)
+    @frequency_from_preference = EmailFrequency.new(minimum_frequency)
   end
 
   def skip?(last_sent_days_ago)
@@ -17,19 +15,17 @@ class EmailRateLimit
   # send an email if you've clicked one in the last 3 days
   # back down to twice a week if they've not clicked in the last 7
   def now?(last_sent_days_ago)
-    case minimum_calculated_frequency
-    when "daily"
+    case less_frequent_of_activity_and_preference.to_s
+    when EmailFrequency::DAILY
       true
-    when "twice_a_week"
+    when EmailFrequency::TWICE_A_WEEK
       last_sent_days_ago.modulo(3).zero?
-    when "once_a_week"
+    when EmailFrequency::ONCE_A_WEEK
       last_sent_days_ago.modulo(7).zero?
-    when "once_a_month"
+    when EmailFrequency::ONCE_A_MONTH
       last_sent_days_ago.modulo(30).zero?
-    when "wait"
+    when EmailFrequency::WAIT
       false
-    else
-      raise "Unknown case: #{frequency}"
     end
   end
 
@@ -39,29 +35,7 @@ class EmailRateLimit
     # send rate as "daily" the higher value will be used i.e. "twice_a_week". If however
     # they are inactive and calculated frequency is "once_a_month" we will use that instead.
     # The highest duration wins between user supplied and calculated
-    def minimum_calculated_frequency
-      return frequency_of_send_rate if @minimum_frequency.blank?
-      return frequency_of_send_rate if !USER_STATES.include?(frequency_of_send_rate)
-
-      if USER_STATES.index(@minimum_frequency) > USER_STATES.index(frequency_of_send_rate)
-        @minimum_frequency
-      else
-        frequency_of_send_rate
-      end
-    end
-
-    def frequency_of_send_rate
-      case @last_clicked_days_ago
-      when 0..3
-        "daily"
-      when 7..13
-        "twice_a_week"
-      when 14..30
-        "once_a_week"
-      when 31..Float::INFINITY
-        "once_a_month"
-      else
-        "wait"
-      end
+    def less_frequent_of_activity_and_preference
+      [@frequency_from_last_click, @frequency_from_preference].min
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,10 @@ class User < ActiveRecord::Base
   validates_uniqueness_of :email,    allow_blank: true, if: :email_changed?
   validates_length_of     :password, within:  8..128, allow_blank: true
   validates :github, presence: true, uniqueness: true
-  validates :email_frequency, inclusion: { in: EmailRateLimit::USER_STATES.map(&:to_s) + [nil] , message: "Not a valid frequency, pick from #{ EmailRateLimit::USER_STATES }" }
+  validates :email_frequency, inclusion: {
+    in: EmailFrequency::USER_FREQUENCIES.map(&:to_s) + [nil] ,
+    message: "Not a valid frequency, pick from #{ EmailFrequency::USER_FREQUENCIES }"
+  }
 
   # Setup accessible (or protected) attributes for your model
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -10,7 +10,7 @@
     .input-preprend
       span.add-on
         i.icon-envelope
-      = f.select :email_frequency, options_for_select( EmailRateLimit::USER_STATES.map {|value| [ value.humanize, value ] }, f.object.email_frequency), class: 'select'
+      = f.select :email_frequency, options_for_select( EmailFrequency::USER_FREQUENCIES.map {|value| [ value.humanize, value ] }, f.object.email_frequency), class: 'select'
       p When you're busy we try to send you less emails, if that's not good enough set your frequency here. For example if you set "twice a week" you won't receive more than 2 emails a week.
 
   = f.label :email_time_of_day, t("activerecord.attributes.user.email_time_of_day", default: "Email time of day"), class: "label label-info"

--- a/test/unit/email_frequency_test.rb
+++ b/test/unit/email_frequency_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class EmailFrequencyTest < ActiveSupport::TestCase
+  test "an invalid frequency is invalid" do
+    assert_raise(ArgumentError) { EmailFrequency.new('foo') }
+  end
+
+  test "#to_s returns the description" do
+    description = EmailFrequency::FREQUENCIES.sample
+
+    assert_equal EmailFrequency.new(description).to_s, description
+  end
+
+  test "frequencies with the same description are eql" do
+    description = EmailFrequency::FREQUENCIES.sample
+    assert_equal EmailFrequency.new(description), EmailFrequency.new(description)
+  end
+
+  test "greater than" do
+    assert EmailFrequency.new("daily") > EmailFrequency.new("twice_a_week")
+  end
+
+  test "less than" do
+    assert EmailFrequency.new("twice_a_week") < EmailFrequency.new("daily")
+  end
+
+  test "#more_often? synonym of >" do
+    assert EmailFrequency.new("daily").more_often? EmailFrequency.new("twice_a_week")
+  end
+
+  test "#less_often? synonmym of <" do
+    assert EmailFrequency.new("twice_a_week").less_often? EmailFrequency.new("daily")
+  end
+end

--- a/test/unit/email_frequency_test.rb
+++ b/test/unit/email_frequency_test.rb
@@ -23,12 +23,4 @@ class EmailFrequencyTest < ActiveSupport::TestCase
   test "less than" do
     assert EmailFrequency.new("twice_a_week") < EmailFrequency.new("daily")
   end
-
-  test "#more_often? synonym of >" do
-    assert EmailFrequency.new("daily").more_often? EmailFrequency.new("twice_a_week")
-  end
-
-  test "#less_often? synonmym of <" do
-    assert EmailFrequency.new("twice_a_week").less_often? EmailFrequency.new("daily")
-  end
 end

--- a/test/unit/email_rate_limit_test.rb
+++ b/test/unit/email_rate_limit_test.rb
@@ -1,23 +1,6 @@
 require 'test_helper'
 
 class EmailRateLimitTest < ActiveSupport::TestCase
-  def seed_array
-    # max value has to be divisible by the multiplier of th higest used value i.e. 10_000/30.0
-    @seed_array ||= (1..350).to_a
-  end
-
-  def block_contents(block)
-    block.source[block.source.index('{')+1...block.source.index('}')]
-  end
-
-  def assert_true(&block)
-    assert block.call, "Expected#{block_contents(block)}to be true"
-  end
-
-  def assert_not_true(&block)
-    assert_not block.call, "Expected#{block_contents(block)}to be false"
-  end
-
   test "decides daily email frequency" do
     # Daily
     last_clicked_days_ago = 0..3
@@ -79,5 +62,22 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     bad_clicked_ago        = invalid_values.sample
     assert_true { EmailRateLimit.new(day_ago).now?(clicked_ago) }
     assert_true { EmailRateLimit.new(day_ago).skip?(bad_clicked_ago) }
+  end
+
+  def seed_array
+    # max value has to be divisible by the multiplier of th higest used value i.e. 10_000/30.0
+    @seed_array ||= (1..350).to_a
+  end
+
+  def block_contents(block)
+    block.source[block.source.index('{')+1...block.source.index('}')]
+  end
+
+  def assert_true(&block)
+    assert block.call, "Expected#{block_contents(block)}to be true"
+  end
+
+  def assert_not_true(&block)
+    assert_not block.call, "Expected#{block_contents(block)}to be false"
   end
 end

--- a/test/unit/email_rate_limit_test.rb
+++ b/test/unit/email_rate_limit_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class EmailRateLimitTest < ActiveSupport::TestCase
   def seed_array
-    @seed_array ||= (1..350).to_a # max value has to be divisible by the multiplier of th higest used value i.e. 10_000/30.0
+    # max value has to be divisible by the multiplier of th higest used value i.e. 10_000/30.0
+    @seed_array ||= (1..350).to_a
   end
 
   test "decides daily email frequency" do
@@ -13,9 +14,12 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     invalid_values        = last_clicked_days_ago.to_a - valid_values
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
+    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
     # Use user email frequency settings
-    assert_not EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_week').now?(#{clicked_ago}) to be false, was not"
+    assert_not EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago),
+      "Expected EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_week').now?(#{clicked_ago}) "\
+        "to be false"
   end
 
   test "wait" do
@@ -26,7 +30,8 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     invalid_values        = last_clicked_days_ago.to_a - valid_values
     day_ago               = rand(last_clicked_days_ago)
     bad_clicked_ago       = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
   end
 
   test "twice a week" do
@@ -38,8 +43,10 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
+    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
   end
 
   test "once a week" do
@@ -51,8 +58,10 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
+    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
   end
 
   test "once a month" do
@@ -64,7 +73,9 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
+    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
+      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
   end
 end

--- a/test/unit/email_rate_limit_test.rb
+++ b/test/unit/email_rate_limit_test.rb
@@ -6,6 +6,18 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     @seed_array ||= (1..350).to_a
   end
 
+  def block_contents(block)
+    block.source[block.source.index('{')+1...block.source.index('}')]
+  end
+
+  def assert_true(&block)
+    assert block.call, "Expected#{block_contents(block)}to be true"
+  end
+
+  def assert_not_true(&block)
+    assert_not block.call, "Expected#{block_contents(block)}to be false"
+  end
+
   test "decides daily email frequency" do
     # Daily
     last_clicked_days_ago = 0..3
@@ -14,12 +26,9 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     invalid_values        = last_clicked_days_ago.to_a - valid_values
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
+    assert_true { EmailRateLimit.new(day_ago).now?(clicked_ago) }
     # Use user email frequency settings
-    assert_not EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago),
-      "Expected EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_week').now?(#{clicked_ago}) "\
-        "to be false"
+    assert_not_true { EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago) }
   end
 
   test "wait" do
@@ -30,8 +39,7 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     invalid_values        = last_clicked_days_ago.to_a - valid_values
     day_ago               = rand(last_clicked_days_ago)
     bad_clicked_ago       = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
+    assert_true { EmailRateLimit.new(day_ago).skip?(bad_clicked_ago) }
   end
 
   test "twice a week" do
@@ -43,10 +51,8 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
+    assert_true { EmailRateLimit.new(day_ago).now?(clicked_ago) }
+    assert_true { EmailRateLimit.new(day_ago).skip?(bad_clicked_ago) }
   end
 
   test "once a week" do
@@ -58,10 +64,8 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
+    assert_true { EmailRateLimit.new(day_ago).now?(clicked_ago) }
+    assert_true { EmailRateLimit.new(day_ago).skip?(bad_clicked_ago) }
   end
 
   test "once a month" do
@@ -73,9 +77,7 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
     bad_clicked_ago        = invalid_values.sample
-    assert EmailRateLimit.new(day_ago).now?(clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true"
-    assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago),
-      "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true"
+    assert_true { EmailRateLimit.new(day_ago).now?(clicked_ago) }
+    assert_true { EmailRateLimit.new(day_ago).skip?(bad_clicked_ago) }
   end
 end


### PR DESCRIPTION
Represents the frequency with which email should be sent. Goal is to simplify the logic for "should we send an email now?", which compares user preference with user actions

In trying to understand the logic and tests in https://github.com/codetriage/codetriage/pull/591, I started moving some code around and ended up with this value object extraction. Not sure if it's wanted, but figured I'd share it nonetheless.