### PR TITLE
Fix fetcher memoization bug

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -24,7 +24,7 @@ class Issue < ActiveRecord::Base
   end
 
   def comments_fetcher
-    @fetcher ||= GithubFetcher::IssueComments.new(
+    @comments_fetcher ||= GithubFetcher::IssueComments.new(
       owner_name: owner_name,
       repo_name: repo_name,
       number: number,


### PR DESCRIPTION
Both `Issue#fetcher` and `Issue#comments_fetcher` were using the same instance variable (`@fetcher`) when memoizing.  

Wasn't sure if it was worth adding a test to expose the memoization bug or not. Let me know if you feel strongly about it, and I can add one. 