### PR TITLE
Use a namespace locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,3 +103,4 @@ gem 'stackprof'
 gem 'bootsnap', require: false
 gem 'rbtrace'
 gem 'trashed'
+gem 'redis-namespace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,8 @@ GEM
     record_tag_helper (1.0.0)
       actionview (~> 5.x)
     redis (3.2.2)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -396,6 +398,7 @@ DEPENDENCIES
   rails_autolink
   rbtrace
   record_tag_helper (~> 1.0)
+  redis-namespace
   rrrretry
   sassc
   sassc-rails!

--- a/config/initializers/mini-profiler.rb
+++ b/config/initializers/mini-profiler.rb
@@ -1,5 +1,5 @@
 # set RedisStore so Rack Mini-Profiler works with multiple servers
-if Rails.env.production?
+if Rails.env.production? && ENV["REDIS_URL"]
   uri = URI.parse(ENV["REDIS_URL"])
   Rack::MiniProfiler.config.storage         = Rack::MiniProfiler::RedisStore
   Rack::MiniProfiler.config.storage_options = { host: uri.host, port: uri.port, password: uri.password }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+unless Rails.env.production?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: ENV["REDIS_URL"], namespace: "codetriage-sidekiq" }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV["REDIS_URL"], namespace: "codetriage-sidekiq"}
+  end
+end


### PR DESCRIPTION
Multiple apps can connect to default sidekiq. Be a good neighbor by using a namespace locally.