### PR TITLE
Fix Github response memoization

### DIFF
--- a/app/models/github_fetcher/issues.rb
+++ b/app/models/github_fetcher/issues.rb
@@ -15,9 +15,5 @@ module GithubFetcher
 
       super
     end
-
-    def more_issues?
-      !response.last_page?
-    end
   end
 end

--- a/app/models/github_fetcher/resource.rb
+++ b/app/models/github_fetcher/resource.rb
@@ -1,7 +1,7 @@
 module GithubFetcher
   # Base class for resources accessible via GitHubBub
   class Resource
-    attr_reader :error_message
+    attr_reader :error_message, :page
 
     # Often over-ridden by subclasses in order to set @api_path. When over-ridden,
     #   it's preferable to call `super` so as to set options as below (and get any
@@ -15,7 +15,7 @@ module GithubFetcher
       @as_json ||= response.json_body
     end
 
-    # Generally not over-riden
+    # Generally not over-ridden
     def response
       @response ||= begin
                       GitHubBub.get(api_path, options)
@@ -31,6 +31,17 @@ module GithubFetcher
       #   error if it happened. `as_json` should always evaluate truthily, but
       #   @error will be false unless there's an error in the API request
       as_json && @error
+    end
+
+    def page=(number)
+      @response = nil
+      @as_json = nil
+      options[:page] = number
+      @page = number
+    end
+
+    def last_page?
+      response.last_page?
     end
 
     private

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -35,12 +35,10 @@ class Repo < ActiveRecord::Base
     fetcher.as_json
   end
 
-  def issues_fetcher(page: 1, state: 'open')
+  def issues_fetcher
     @issues_fetcher ||= GithubFetcher::Issues.new(
       user_name: user_name,
-      name: name,
-      page: page,
-      state: state,
+      name: name
     )
   end
 

--- a/test/jobs/populate_issues_job_test.rb
+++ b/test/jobs/populate_issues_job_test.rb
@@ -29,11 +29,11 @@ class PopulateIssuesJobTest < ActiveJob::TestCase
 
   test "#populate_multi_issues stores error info when fails" do
     repo = repos(:issue_triage_sandbox)
-    fetcher_double = OpenStruct.new(error?: true, error_message: 'something went wrong')
-
-    repo.stub(:issues_fetcher, -> (_) { fetcher_double }) do
-      PopulateIssuesJob.perform_now(repo)
-      assert_equal repo.github_error_msg, 'something went wrong'
+    def repo.issues_fetcher
+      OpenStruct.new(error?: true, error_message: 'something went wrong', page: 1)
     end
+
+    PopulateIssuesJob.perform_now(repo)
+    assert_equal repo.github_error_msg, 'something went wrong'
   end
 end

--- a/test/unit/github_fetcher/issues_test.rb
+++ b/test/unit/github_fetcher/issues_test.rb
@@ -23,16 +23,32 @@ class GithubFetcher::IssuesTest < ActiveSupport::TestCase
   end
 
   test "#as_json can get second page of issues" do
-    repo = repos(:rails_rails)
-    fetcher = GithubFetcher::Issues.new(user_name: repo.user_name, name: repo.name, page: 2)
+    fetcher = fetcher(repos(:rails_rails))
+    fetcher.page = 2
 
     VCR.use_cassette "rails_rails_fetch_issues_page_two" do
       as_json = fetcher.as_json
-      assert_equal as_json.size, 30, as_json
-      assert_equal as_json.first['title'], "Give clients a way to refer to ActionDispatch "\
-        "middleware classes without triggering an early load of ActionDispatch"
-      assert_equal as_json.last['title'], "default_scope breaks chained having "\
-        "statements in rails4"
+      assert_equal 30, as_json.size, as_json
+      assert_equal "Give clients a way to refer to ActionDispatch "\
+        "middleware classes without triggering an early load of ActionDispatch", as_json.first['title']
+      assert_equal "default_scope breaks chained having "\
+        "statements in rails4", as_json.last['title']
+    end
+  end
+
+  test "correctly caches when paginating" do
+    fetcher = fetcher(repos(:rails_rails))
+
+    VCR.use_cassette "rails_rails_fetch_issues" do
+      assert_equal "Missing helper file helpers//Users/xxxx/"\
+        "Sites/xxxx/app/helpers/application_helper.rb_helper.rb", fetcher.as_json.first['title']
+    end
+
+    fetcher.page = 2
+
+    VCR.use_cassette "rails_rails_fetch_issues_page_two" do
+      assert_equal "Give clients a way to refer to ActionDispatch "\
+        "middleware classes without triggering an early load of ActionDispatch", fetcher.as_json.first['title']
     end
   end
 
@@ -43,17 +59,17 @@ class GithubFetcher::IssuesTest < ActiveSupport::TestCase
     end
   end
 
-  test "#more_issues? is true when it's the last page" do
+  test "#last_page is true when it's the last page" do
     fetcher = fetcher(repos(:rails_rails))
     GitHubBub.stub(:get, -> (_, _) { OpenStruct.new(last_page?: true) } ) do
-      assert_not fetcher.more_issues?
+      assert fetcher.last_page?
     end
   end
 
-  test "#more_issues? is false when it's not the last page" do
+  test "#last_page is false when it's not the last page" do
     fetcher = fetcher(repos(:rails_rails))
     GitHubBub.stub(:get, -> (_, _) { OpenStruct.new(last_page?: false) } ) do
-      assert fetcher.more_issues?
+      assert_not fetcher.last_page?
     end
   end
 


### PR DESCRIPTION
Changing options blows the cache.
+ Add page change method
+ Move last page? to Resource
+ Remove state setting on job, b/c it's just the default.