### PR TITLE
Use git checkout in instructions instead of git co

### DIFF
--- a/app/views/doc_methods/show.html.slim
+++ b/app/views/doc_methods/show.html.slim
@@ -35,7 +35,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
       pre
         |
           # Make a new branch
-          $ git co -b #{ @branch }
+          $ git checkout -b #{ @branch }
 
           # Commit to git
           $ git add #{ @doc.file }


### PR DESCRIPTION
Git doesn't have a `co` command, I think we want `checkout` instead. The original author probably had it as an alias.