### PR TITLE
Fix email not sending at preferred time

### DIFF
--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -2,7 +2,7 @@ class SendDailyTriageEmailJob < ApplicationJob
   def perform(user)
     return false if before_email_time_of_day?(user)
     return false if user.repo_subscriptions.empty?
-    return false if email_sent_in_last_24_hours?(user)
+    return false if email_sent_today?(user)
     return false if skip_daily_email?(user)
 
     send_daily_triage!(user)
@@ -22,8 +22,8 @@ class SendDailyTriageEmailJob < ApplicationJob
     mail
   end
 
-  def email_sent_in_last_24_hours?(user)
-    user.repo_subscriptions.where("last_sent_at > ?", 24.hours.ago).any?
+  def email_sent_today?(user)
+    user.repo_subscriptions.where("last_sent_at >= ?", Time.current.beginning_of_day).any?
   end
 
   def skip_daily_email?(user)

--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -23,7 +23,7 @@ class SendDailyTriageEmailJob < ApplicationJob
   end
 
   def email_sent_in_last_24_hours?(user)
-    user.repo_subscriptions.where("last_sent_at >= ?", 24.hours.ago).any?
+    user.repo_subscriptions.where("last_sent_at > ?", 24.hours.ago).any?
   end
 
   def skip_daily_email?(user)

--- a/test/jobs/send_daily_triage_email_job_test.rb
+++ b/test/jobs/send_daily_triage_email_job_test.rb
@@ -50,12 +50,12 @@ class SendDailyTriageEmailJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'when email_time_of_day set, it delivers after preferred time of day' do
+  test 'when email_time_of_day set, it delivers at preferred time of day' do
     def @user.issue_assignments_to_deliver; IssueAssignment.all.limit(1); end
 
     def @user.email_time_of_day; Time.utc(2000, 1, 1, 04, 0, 0); end
 
-    Time.stub(:now, time_preference_for_today(@user.email_time_of_day) + 1.hour) do
+    Time.stub(:now, time_preference_for_today(@user.email_time_of_day)) do
       assert_enqueued_jobs 1 do
         @job.perform(@user)
       end


### PR DESCRIPTION
Fixes https://github.com/codetriage/codetriage/issues/615

Checking for a sent email in last 24 hours means that if you change the preference to earlier, the email will still get held back until the 24 hours is up, and this cycle will continue.

Instead we check if an email has been sent since the start of the day.

Thanks to @charlietarr1 for pairing with me on this.