### PR TITLE
Split test and rubocop tasks for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
   - gem install bundler --no-document
   - bundle install
 script:
-  - RAILS_ENV=test bin/rake
+  - bundle exec rake test
+  - bundle exec rake rubocop
 before_script:
   - cp config/database.example.yml config/database.yml
   - psql -c 'create database triage_test;' -U postgres


### PR DESCRIPTION
As discussed with @elliotthilaire on #619 

> I wasn't suggesting we make the build green if it shouldn't be. Instead if the rubocop and tests fail, we can find out in a single build instead of two.

