### PR TITLE
Update GitHubBub to v1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
       dotenv (= 2.2.1)
       railties (>= 3.2, < 5.2)
     erubi (1.6.0)
-    excon (0.45.4)
+    excon (0.58.0)
     execjs (2.7.0)
     faker (1.7.3)
       i18n (~> 0.5)
@@ -129,7 +129,7 @@ GEM
     foreman (0.78.0)
       thor (~> 0.19.1)
     get_process_mem (0.2.0)
-    git_hub_bub (0.0.6)
+    git_hub_bub (1.0.0)
       excon
       rrrretry
     globalid (0.4.0)
@@ -434,4 +434,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/models/github_fetcher/resource.rb
+++ b/app/models/github_fetcher/resource.rb
@@ -22,14 +22,14 @@ module GithubFetcher
                       response.rate_limit_sleep!
                       unless response.success?
                         @error         = true
-                        @error_message = "Expecting a 2.x.x response but status was #{response.status}"
+                        @error_message = "Expecting a 2.x.x response but status was #{response.status} body:\n#{response.body}"
                         response       = null_response(response.body, status: response.status)
                       end
                       response
                     rescue => e
                       @error = e
                       @error_message = e.message
-                      null_response(e)
+                      null_response
                     end
     end
 
@@ -56,8 +56,9 @@ module GithubFetcher
     attr_reader :api_path, :options
 
     # Sometimes over-ridden to use the error
-    def null_response(_error, status: nil)
-      GitHubBub::Response.new(body: null_response_body.to_json, status: status)
+    def null_response(_error = nil, status: nil)
+      body = _error || null_response_body.to_json
+      GitHubBub::Response.new(body: body, status: status)
     end
 
     # Sometimes over-ridden to set a specific response when GitHubBub API call

--- a/app/models/github_fetcher/user.rb
+++ b/app/models/github_fetcher/user.rb
@@ -6,11 +6,9 @@ module GithubFetcher
     end
 
     def valid?
-      begin
-        GitHubBub.valid_token?(@options[:token])
-      rescue GitHubBub::RequestError
-        false
-      end
+      response = GitHubBub.valid_token?(@options[:token])
+      response.rate_limit_sleep! if response
+      response
     end
   end
 end

--- a/app/services/git_hub_authenticator.rb
+++ b/app/services/git_hub_authenticator.rb
@@ -37,7 +37,11 @@ class GitHubAuthenticator
 
   def github_email
     return auth_email if auth_email.present?
-    GithubFetcher::Email.new(token: token).as_json.first
+    fetcher = GithubFetcher::Email.new(token: token)
+    if fetcher.error?
+      raise fetcher.error_message
+    end
+    fetcher.as_json.first
   end
 
   def github_params

--- a/test/unit/git_hub_authenticator_test.rb
+++ b/test/unit/git_hub_authenticator_test.rb
@@ -36,7 +36,7 @@ class GitHubAuthenticatorTest < ActiveSupport::TestCase
       credentials: { token: '123qwe' }
     )
 
-    emails = Struct.new(:json_body).new ['john.doe@example.com']
+    emails = Struct.new(:json_body, :success?, :rate_limit_sleep!).new(['john.doe@example.com'], true)
     GitHubBub.expects(:get).with("/user/emails", token: '123qwe')
              .returns emails
 

--- a/test/unit/github_fetcher/email_test.rb
+++ b/test/unit/github_fetcher/email_test.rb
@@ -17,12 +17,4 @@ class GithubFetcher::EmailTest < ActiveSupport::TestCase
       ], "Failed: Got #{email_fetcher.as_json}"
     end
   end
-
-  test "#as_json returns null response when bad request" do
-    VCR.use_cassette "bad_fetch_emails" do
-      email_fetcher = GithubFetcher::Email.new(token: 'asdf')
-
-      assert_equal email_fetcher.as_json, [{}]
-    end
-  end
 end

--- a/test/unit/github_fetcher/issues_test.rb
+++ b/test/unit/github_fetcher/issues_test.rb
@@ -68,7 +68,8 @@ class GithubFetcher::IssuesTest < ActiveSupport::TestCase
 
   test "#last_page is false when it's not the last page" do
     fetcher = fetcher(repos(:rails_rails))
-    GitHubBub.stub(:get, ->(_, _) { OpenStruct.new(last_page?: false) }) do
+    GitHubBub.stub(:get, -> (_, _) { OpenStruct.new(last_page?: false, :success? => true) } ) do
+      assert_not fetcher.error?
       assert_not fetcher.last_page?
     end
   end

--- a/test/unit/github_fetcher/issues_test.rb
+++ b/test/unit/github_fetcher/issues_test.rb
@@ -68,7 +68,7 @@ class GithubFetcher::IssuesTest < ActiveSupport::TestCase
 
   test "#last_page is false when it's not the last page" do
     fetcher = fetcher(repos(:rails_rails))
-    GitHubBub.stub(:get, -> (_, _) { OpenStruct.new(last_page?: false, :success? => true) } ) do
+    GitHubBub.stub(:get, ->(_, _) { OpenStruct.new(last_page?: false, :success? => true) }) do
       assert_not fetcher.error?
       assert_not fetcher.last_page?
     end

--- a/test/unit/github_fetcher/user_test.rb
+++ b/test/unit/github_fetcher/user_test.rb
@@ -46,7 +46,7 @@ class GithubFetcher::UserTest < ActiveSupport::TestCase
   end
 
   test "#valid? returns false when API error occurs" do
-    GitHubBub.stub(:valid_token?, ->(_) { raise GitHubBub::RequestError }) do
+    GitHubBub.stub(:valid_token?, -> (_) { false }) do
       user_fetcher = GithubFetcher::User.new(token: 'asdf')
 
       assert_not user_fetcher.valid?

--- a/test/unit/github_fetcher/user_test.rb
+++ b/test/unit/github_fetcher/user_test.rb
@@ -46,7 +46,7 @@ class GithubFetcher::UserTest < ActiveSupport::TestCase
   end
 
   test "#valid? returns false when API error occurs" do
-    GitHubBub.stub(:valid_token?, -> (_) { false }) do
+    GitHubBub.stub(:valid_token?, ->(_) { false }) do
       user_fetcher = GithubFetcher::User.new(token: 'asdf')
 
       assert_not user_fetcher.valid?


### PR DESCRIPTION
GitHubBub no longer raises exceptions by default. Also `GitHubBub.valid_token?` now explicitly checks for a 404 response to return a false rather than returning false on anything but 200.

Also adds rate limiting code.

See: https://github.com/schneems/git_hub_bub