### PR TITLE
Remove N+1 on UserMailer#send_daily_triage

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,10 +6,11 @@ class UserMailer < ActionMailer::Base
 
   def send_daily_triage(user_id:, assignment_ids:)
     user = User.find(user_id)
-    assignments = IssueAssignment.find(assignment_ids)
-
     return unless set_and_check_user(user)
-    @assignments = assignments
+
+    @assignments =
+      IssueAssignment.includes(:issue, :user, :repo).find(assignment_ids)
+
     @max_days    = 2
     subject = ""
     @days   = @user.days_since_last_clicked


### PR DESCRIPTION
When UserMailer render the emails, the view have a N+1 since it is trying to get properties from issue, user and repo relations on the loop of assignments.

https://github.com/codetriage/codetriage/blob/b3d7a1186e21608052f48d9a9c86eb4c400b7b40/app/views/user_mailer/send_daily_triage.md.erb#L6-L16

Also:

- removing an extra assignment on the assignments ivar
- moving the set_and_check_user guard before performing the query