### PR TITLE
Issue assigner shouldn't raise

### DIFF
--- a/app/models/issue_assigner.rb
+++ b/app/models/issue_assigner.rb
@@ -44,11 +44,11 @@ class IssueAssigner
 
     return false if issue.blank?
     if issue.valid_for_user?(user)
-      sub.issue_assignments.create!(issue_id: issue.id)
+      sub.issue_assignments.create(issue_id: issue.id)
     else
       # prevent selecting this issue again and try to find another one
-      sub.issue_assignments.create!(issue_id: issue.id, delivered: true)
-      assign_issue_for_sub(sub) # yay recursion!
+      sub.issue_assignments.create(issue_id: issue.id, delivered: true) &&
+        assign_issue_for_sub(sub) # yay recursion!
     end
   end
 end


### PR DESCRIPTION
Fix CODETRIAGE-DY

Sometimes this fails because an issue is already assigned. In that case
we don't want to raise, just ignore and keep moving.