### PR TITLE
Fix issue with unreliable test

### DIFF
--- a/test/unit/email_rate_limit_test.rb
+++ b/test/unit/email_rate_limit_test.rb
@@ -12,9 +12,10 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     valid_values          = seed_array.map { |n| n * multiplier }
     day_ago               = rand(last_clicked_days_ago)
     clicked_ago           = valid_values.sample
+
     assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
     # Use user email frequency settings
-    assert_not EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_week').now?(#{clicked_ago}) to be false, was not"
+    assert EmailRateLimit.new(day_ago, minimum_frequency: "daily").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'daily').now?(#{clicked_ago}) to be true, was not"
   end
 
   test "wait" do
@@ -39,6 +40,9 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     bad_clicked_ago = invalid_values.sample
     assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
     assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+
+    # Use user email frequency settings
+    assert EmailRateLimit.new(day_ago, minimum_frequency: "twice_a_week").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'twice_a_week').now?(#{clicked_ago}) to be true, was not"
   end
 
   test "once a week" do
@@ -52,6 +56,9 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     bad_clicked_ago = invalid_values.sample
     assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
     assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+
+    # Use user email frequency settings
+    assert EmailRateLimit.new(day_ago, minimum_frequency: "once_a_week").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_week').now?(#{clicked_ago}) to be true, was not"
   end
 
   test "once a month" do
@@ -65,5 +72,8 @@ class EmailRateLimitTest < ActiveSupport::TestCase
     bad_clicked_ago = invalid_values.sample
     assert EmailRateLimit.new(day_ago).now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).now?(#{clicked_ago}) to be true, was not"
     assert EmailRateLimit.new(day_ago).skip?(bad_clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}).skip?(#{bad_clicked_ago}) to be true, was not"
+
+    # Use user email frequency settings
+    assert EmailRateLimit.new(day_ago, minimum_frequency: "once_a_month").now?(clicked_ago), "Expected  EmailRateLimit.new(#{day_ago}, minimum_frequency: 'once_a_month').now?(#{clicked_ago}) to be true, was not"
   end
 end


### PR DESCRIPTION
This PR is to address #541

This test was computing date ranges for daily notification, but then asserting EmailRateLimit behavior based on a weekly preference.  Whenever the random value for clicked_ago was divisible by 7, the last assertion would fail, but in all other cases it passed.

I rewrote the assertion to pass a daily preference (to match the logic of how clicked_ago was generated), then added similar assertion to other intervals.

I ran this one-liner to confirm before and after behavior.
```
for ((i=1;i<=100;i++)); do rake test TEST=test/unit/email_rate_limit_test.rb ; done;
```