### PR TITLE
remove Repo#path in favor of Repo#full_name, closes #587

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -32,7 +32,7 @@ class UserMailer < ActionMailer::Base
     return unless set_and_check_user(user)
     @repo  = repo
     @issue = assignment.issue
-    mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "Help Triage #{@repo.path} on GitHub")
+    mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "Help Triage #{@repo.full_name} on GitHub")
   end
 
   def poke_inactive(user:)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -145,7 +145,7 @@ class Repo < ActiveRecord::Base
   end
 
   def to_param
-    path
+    full_name
   end
 
   def self.order_by_issue_count
@@ -161,11 +161,7 @@ class Repo < ActiveRecord::Base
   end
 
   def github_url
-    File.join('https://github.com', path)
-  end
-
-  def path
-    "#{user_name}/#{name}"
+    File.join('https://github.com', full_name)
   end
 
   def self.exists_with_name?(name)

--- a/app/views/user_mailer/poke_inactive.html.erb
+++ b/app/views/user_mailer/poke_inactive.html.erb
@@ -4,13 +4,13 @@ Hello <%= @user.github %>,<br /><br />
 You signed up to make a difference by triaging issues in github, which is great, but you didn't actually subscribe to any projects. To fix this just click on a link below, sign in, then click on the giant "subscribe" button:<br /><br />
 
 Help the repo with the most issues:
-<h3><%= link_to @most_repo.path, repo_url(@most_repo) %></h3><br />
+<h3><%= link_to @most_repo.full_name, repo_url(@most_repo) %></h3><br />
 
 Help a repo in need:
-<h3><%= link_to @need_repo.path , repo_url(@need_repo) %></h3><br />
+<h3><%= link_to @need_repo.full_name , repo_url(@need_repo) %></h3><br />
 
 Help a random repo:
-<h3><%= link_to @random_repo.path, repo_url(@random_repo) %></h3><br />
+<h3><%= link_to @random_repo.full_name, repo_url(@random_repo) %></h3><br />
 
 If you don't like any of those <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , root_url %> repos, or you can even subscribe to <%= link_to "code triage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.<br /><br />
 

--- a/app/views/user_mailer/poke_inactive.text.erb
+++ b/app/views/user_mailer/poke_inactive.text.erb
@@ -5,13 +5,13 @@ great, but you didn't actually subscribe to any projects. To fix this just
 click on a link below, sign in, then click on the giant "subscribe" button:
 
 Help the repo with the most issues:
-<%= @most_repo.path %> (<%= repo_url(@most_repo) %>)
+<%= @most_repo.full_name %> (<%= repo_url(@most_repo) %>)
 
 Help a repo in need:
-<%= @need_repo.path %> (<%= repo_url(@need_repo) %>)
+<%= @need_repo.full_name %> (<%= repo_url(@need_repo) %>)
 
 Help a random repo:
-<%= @random_repo.path =%> (<%= repo_url(@random_repo) %>)
+<%= @random_repo.full_name %> (<%= repo_url(@random_repo) %>)
 
 If you don't like any of those add your own repo (<%= new_repo_url %>), browse
 existing repos (<%= root_url %>), or you can even subscribe to code triage

--- a/app/views/user_mailer/send_triage.html.erb
+++ b/app/views/user_mailer/send_triage.html.erb
@@ -1,10 +1,10 @@
 Hello <%= @user.github %>,
 
 <p>
-You signed up to help triage GitHub issues on <%= link_to @repo.path, @repo.github_url %>. That's pretty awesome.
+You signed up to help triage GitHub issues on <%= link_to @repo.full_name, @repo.github_url %>. That's pretty awesome.
 </p>
 
-<h2>Triage Issue: <%= @repo.path %><%= "##{@issue.number}" if @issue.number %></h2>
+<h2>Triage Issue: <%= @repo.full_name %><%= "##{@issue.number}" if @issue.number %></h2>
 
 <h2><%= link_to @issue.title, @issue.html_url %></h2>
 
@@ -46,7 +46,7 @@ If the issue goes stale, leave a comment asking if it is still a problem. If you
 
 <hr />
 
-<p><%= link_to "Send another #{@repo.path} issue", repo_url(@repo) %></p>
-<p><%= link_to "Unsubscribe: #{@repo.path}", repo_url(@repo) %></p>
+<p><%= link_to "Send another #{@repo.full_name} issue", repo_url(@repo) %></p>
+<p><%= link_to "Unsubscribe: #{@repo.full_name}", repo_url(@repo) %></p>
 <p><%= link_to "Remove Account", token_delete_user_url(@user.account_delete_token) %></p>
 <p><%= link_to 'Help triage more repos at codetriage.com', root_url %></p>

--- a/app/views/user_mailer/send_triage.text.erb
+++ b/app/views/user_mailer/send_triage.text.erb
@@ -1,9 +1,9 @@
 Hello <%= @user.github %>,
 
-You signed up to help triage GitHub issues on <%= @repo.path %> (<%= @repo.github_url %>).
+You signed up to help triage GitHub issues on <%= @repo.full_name %> (<%= @repo.github_url %>).
 That's pretty awesome.
 
-Triage Issue: <%= @repo.path %><%= "##{@issue.number}" if @issue.number %>
+Triage Issue: <%= @repo.full_name %><%= "##{@issue.number}" if @issue.number %>
 
 <%= @issue.title %> (<%= @issue.html_url %>)
 
@@ -51,7 +51,7 @@ Sincerely,
 
 --
 
-Send another <%= @repo.path %> issue: <%= repo_url(@repo) %>
-Unsubscribe from <%= @repo.path %>: <%=  repo_url(@repo) %>
+Send another <%= @repo.full_name %> issue: <%= repo_url(@repo) %>
+Unsubscribe from <%= @repo.full_name %>: <%=  repo_url(@repo) %>
 Remove Account: <%= token_delete_user_url(@user.account_delete_token) %>
 Help triage more repos at codetriage.com: <%= root_url %>

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -1,7 +1,22 @@
 require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "send_triage works" do
+    repo_sub = repo_subscriptions(:schneems_to_triage)
+    assignment = issue_assignments(:one)
+    email = UserMailer.send_triage(repo: repo_sub.repo, user: repo_sub.user, assignment: assignment)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+  end
+
+  test "poke_inactive works" do
+    user = users(:schneems)
+    email = UserMailer.poke_inactive(user: user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+  end
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -57,17 +57,17 @@ class RepoTest < ActiveSupport::TestCase
   # CI can switch the ordering of these repos, but we dont care about ordering,
   # so use set intersection
   test "repos needing help when user has ruby language" do
-    repos = Repo.repos_needing_help_for_user(User.new(favorite_languages: ["ruby"])).map(&:path)
+    repos = Repo.repos_needing_help_for_user(User.new(favorite_languages: ["ruby"])).map(&:full_name)
     assert_operator ["bemurphy/issue_triage_sandbox", "sinatra/sinatra"], "&", repos
   end
 
   test "repos needing help when user has no languages" do
-    repos = Repo.repos_needing_help_for_user(User.new(favorite_languages: [])).map(&:path)
+    repos = Repo.repos_needing_help_for_user(User.new(favorite_languages: [])).map(&:full_name)
     assert_operator ["bemurphy/issue_triage_sandbox", "sinatra/sinatra", "andrewrk/groovebasin"], "&", repos
   end
 
   test "repos needing help when user is null" do
-    repos = Repo.repos_needing_help_for_user(nil).map(&:path)
+    repos = Repo.repos_needing_help_for_user(nil).map(&:full_name)
     assert_operator ["bemurphy/issue_triage_sandbox", "sinatra/sinatra", "andrewrk/groovebasin"], "&", repos
   end
 


### PR DESCRIPTION
This resolves the extra code noted on #587.  As noted there, full_name is not available until the record is persisted, but (at least now) the tests all pass and the app seems to work anyway so I went with it as-is.  If it turns out that's a problem, please point me in the right direction so I can add a test and adjust this to get it passing.