### PR TITLE
use render_async to speed up repos#new, resolves #594

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'neat'
 gem 'normalize-rails'
 gem 'slim-rails'
 gem 'uglifier', '>= 1.0.3'
+gem 'render_async', '~> 1.1', '>= 1.1.2'
 
 group :development do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,8 @@ GEM
     redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    render_async (1.1.2)
+      bundler (~> 1.8)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -416,6 +418,7 @@ DEPENDENCIES
   rbtrace
   record_tag_helper (~> 1.0)
   redis-namespace
+  render_async (~> 1.1, >= 1.1.2)
   rrrretry
   rubocop (= 0.49.1)
   sassc

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -7,11 +7,6 @@ class ReposController < RepoBasedController
   def new
     @repo = Repo.new(user_name: params[:user_name], name: name_from_params(params))
     @repo_sub = RepoSubscription.new
-    if user_signed_in?
-      @own_repos     = cached_repos 'repos', current_user.own_repos_json
-      @starred_repos = cached_repos 'starred', current_user.starred_repos_json
-      @watched_repos = cached_repos 'subscriptions', current_user.subscribed_repos_json
-    end
   end
 
   def show
@@ -50,6 +45,21 @@ class ReposController < RepoBasedController
     else
       render :edit
     end
+  end
+
+  def list
+    @repo = Repo.new(user_name: params[:user_name], name: name_from_params(params))
+    if user_signed_in?
+      case params[:show]
+      when 'own'
+        @repos = cached_repos 'repos', current_user.own_repos_json
+      when 'starred'
+        @repos = cached_repos 'starred', current_user.starred_repos_json
+      when 'watched'
+        @repos = cached_repos 'subscriptions', current_user.subscribed_repos_json
+      end
+    end
+    render layout: nil
   end
 
   private

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,3 +10,5 @@ html
       = yield
 
     = render "footer"
+
+  = content_for :render_async

--- a/app/views/repos/list.html.slim
+++ b/app/views/repos/list.html.slim
@@ -1,0 +1,1 @@
+= render 'shared/add_repos_list', repos: @repos

--- a/app/views/repos/new.html.slim
+++ b/app/views/repos/new.html.slim
@@ -23,13 +23,13 @@
 
       .tab-content
         .tab-pane.active#own
-          = render 'shared/add_repos_list', repos: @own_repos
+          = render_async list_repos_path(show: :own)
 
         .tab-pane#starred
-          = render 'shared/add_repos_list', repos: @starred_repos
+          = render_async list_repos_path(show: :starred)
 
         .tab-pane#watched
-          = render 'shared/add_repos_list', repos: @watched_repos
+          = render_async list_repos_path(show: :watched)
 
   section.content-section
     h2.content-section-title Add another repo by pasting the full repo URL

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,11 @@ CodeTriage::Application.routes.draw do
   # format: false gives us rails 3.0 style routes so angular/angular.js is interpreted as
   # user_name: "angular", name: "angular.js" instead of using the "js" as a format
   scope format: false do
-    resources :repos, only: %w[index new create]
+    resources :repos, only: %w[index new create] do
+      collection do
+        get :list
+      end
+    end
 
     scope '*full_name' do
       constraints full_name: /[-_a-zA-Z0-9]+\/[-_\.a-zA-Z0-9]+/ do


### PR DESCRIPTION
As requested on #594, this uses render_async to fill in repos#new.

Big thanks to @nikolalsvk for cutting the new release of render_async on https://github.com/renderedtext/render_async/pull/35