### PR TITLE
Schneems/fix doc method

### DIFF
--- a/app/models/doc_method.rb
+++ b/app/models/doc_method.rb
@@ -28,7 +28,7 @@ class DocMethod < ActiveRecord::Base
 
   def file
     return nil if raw_file.blank?
-    _absolute, _match, relative = raw_file.partition(/(\/|^)#{repo.name}\//)
+    _absolute, _match, relative = raw_file.partition(/(\/|^)#{repo.name}\//i)
     return relative
   end
 

--- a/app/views/doc_methods/show.html.slim
+++ b/app/views/doc_methods/show.html.slim
@@ -8,7 +8,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
 
   .repo-body
     section.help-triage.content-section
-      h2.content-section-title= link_to @doc.path, @doc.to_github + "falksdjflaksdjflkasdjf"
+      h2.content-section-title= link_to @doc.to_github
 
       - if comment = @doc.doc_comments.first
         p


### PR DESCRIPTION
[close #646] Ignore case of file name

We downcase repo names, but not files on disk. When comparing a file name with mixed case to a repo with a downcased name, it will fail.
