### PR TITLE
[close #614] Don’t assign issues, if pending

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -152,6 +152,9 @@ class User < ActiveRecord::Base
   end
 
   def issue_assignments_to_deliver(assign: true)
+    prior_assignments = issue_assignments.where(delivered: false).limit(daily_issue_limit)
+    return prior_assignments unless prior_assignments.blank?
+
     issue_assigner.assign! if assign
     issue_assignments.where(delivered: false).limit(daily_issue_limit)
   end


### PR DESCRIPTION
When pending issues exist, do not assign new issues. We do this for the case where this method is being retried.