### PR TITLE
Faster badge response times without network request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,3 +111,4 @@ gem 'rbtrace'
 gem 'redis-namespace'
 gem 'barnes', git: "https://github.com/heroku/barnes"
 gem 'stackprof'
+gem 'prawn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,8 +219,12 @@ GEM
     parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
+    pdf-core (0.7.0)
     pg (0.18.3)
     powerpack (0.1.1)
+    prawn (2.2.2)
+      pdf-core (~> 0.7.0)
+      ttfunk (~> 1.5)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -230,7 +234,7 @@ GEM
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
-    rack-mini-profiler (0.10.5)
+    rack-mini-profiler (0.10.7)
       rack (>= 1.2.0)
     rack-protection (2.0.0)
       rack
@@ -340,6 +344,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     trollop (2.1.2)
+    ttfunk (1.5.1)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -407,6 +412,7 @@ DEPENDENCIES
   omniauth (= 1.3.1)
   omniauth-github
   pg
+  prawn
   pry
   puma (~> 3.x)
   rack-canonical-host
@@ -449,4 +455,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,5 +1,8 @@
 class BadgesController < ApplicationController
-  rescue_from(Excon::Errors::Timeout, with: :render_503)
+  SHIELD_PDF = Prawn::Document.new
+  SHIELD_PDF.font("Helvetica-Bold")
+  SHIELD_PDF.font_size = 10.858
+  private_constant :SHIELD_PDF
 
   def show
     repo = Repo.where(full_name: permitted[:full_name]).first
@@ -7,19 +10,8 @@ class BadgesController < ApplicationController
 
     case permitted[:badge_type]
     when "users"
-      count = repo.users.count.to_s
-      key   = repo.cache_key + "/badges/".freeze + count
-
-      unless (svg = Rails.cache.read(key))
-        result = Excon.get(
-          "https://img.shields.io/badge/code%20helpers-#{count}-#{repo.color}.svg",
-          read_timeout: 3,
-          idempotent: true
-        )
-        raise ActionController::RoutingError.new('Not Found') unless result.status == 200
-        svg = result.body
-        Rails.cache.write(key, result.body, expires_in: 1.day)
-      end
+      count = repo.users.count
+      svg = make_shield(name: "code helpers", count: count, color_b: repo.color)
     else
       raise ActionController::RoutingError.new('Not Found')
     end
@@ -34,6 +26,42 @@ class BadgesController < ApplicationController
   end
 
   private
+
+  def escapeXml(var)
+    var
+  end
+
+  def make_shield(name:, count:, color_a: "555", color_b: "4c1", logo_width: 0, logo_padding: 0)
+    name_width  = (SHIELD_PDF.width_of(name.to_s) + 10).to_f
+    count_width = (SHIELD_PDF.width_of(count.to_s) + 10).to_f
+    total_width = name_width + count_width
+    svg = <<~EOS
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="#{total_width}" height="20">
+        <linearGradient id="smooth" x2="0" y2="100%">
+          <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+          <stop offset="1" stop-opacity=".1"/>
+        </linearGradient>
+
+        <clipPath id="round">
+          <rect width="#{total_width}" height="20" rx="3" fill="#fff"/>
+        </clipPath>
+
+        <g clip-path="url(#round)">
+          <rect width="#{name_width}" height="20" fill="##{escapeXml(color_a)}"/>
+          <rect x="#{name_width}" width="#{count_width}" height="20" fill="##{escapeXml(color_b)}"/>
+          <rect width="#{total_width}" height="20" fill="url(#smooth)"/>
+        </g>
+
+        <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+          <text x="#{(((name_width + logo_width + logo_padding) / 2) + 1) * 10}" y2="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="#{(name_width - (10 + logo_width + logo_padding)) * 10}" lengthAdjust="spacing">#{escapeXml(name)}</text>
+          <text x="#{(((name_width + logo_width + logo_padding) / 2) + 1) * 10}" y="140" transform="scale(0.1)" textLength="#{(name_width - (10 + logo_width + logo_padding)) * 10}" lengthAdjust="spacing">#{escapeXml(name)}</text>
+          <text x="#{(name_width + count_width / 2 - 1) * 10}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="#{(count_width - 10) * 10}" lengthAdjust="spacing">#{escapeXml(count)}</text>
+          <text x="#{(name_width + count_width / 2 - 1) * 10}" y="140" transform="scale(0.1)" textLength="#{(count_width - 10) * 10}" lengthAdjust="spacing">#{escapeXml(count)}</text>
+        </g>
+      </svg>
+    EOS
+    return svg
+  end
 
   def permitted
     params.permit(:full_name, :badge_type)


### PR DESCRIPTION
The badge endpoint is one of the slower endpoints. By not relying on a network connection we can instead build our own SVG in a fraction of the time.

This code is a port of https://github.com/badges/shields/blob/master/lib/make-badge.js script and the flat template https://github.com/badges/shields/blob/master/templates/flat-template.svg. 

For the weird font size of 10.858, I adjusted prawn’s size until it matched the output of the same string from sheilds.io (running locally).