### PR TITLE
style: improve user token delete page

### DIFF
--- a/app/assets/stylesheets/components/_hero.scss
+++ b/app/assets/stylesheets/components/_hero.scss
@@ -3,8 +3,12 @@
   padding-top: 4rem;
   text-align: center;
 
-  .button {
+  .button, .actions {
     margin-top: 3rem;
+  }
+
+  .actions * + * {
+    margin-left: 1rem;
   }
 
   .github-icon {

--- a/app/views/users/token_delete.html.slim
+++ b/app/views/users/token_delete.html.slim
@@ -1,7 +1,8 @@
-.alert.alert-error
+.hero
   | Are you sure you want to delete your account and stop receiving triage emails at
-  strong= @user.email
+  strong<= @user.email
   | ?
-= form_for @user, url: token_delete_user_path(@user.account_delete_token), method: :delete, html_options: { class: "form form-horizontal" } do |f|
-  = f.submit "Yes, Delete My Account", class: "btn btn-danger"
-  = link_to "No, Cancel", root_url, class: "btn"
+  = form_for @user, url: token_delete_user_path(@user.account_delete_token), method: :delete, html_options: { class: "form form-horizontal" } do |f|
+    .actions
+      = f.submit "Yes, Delete My Account", class: "btn btn-danger"
+      = link_to "No, Cancel", root_url, class: "btn"


### PR DESCRIPTION
Good morning,

This PR is attempt to close: https://github.com/codetriage/codetriage/issues/662

After improvements the page looks like this:

<img width="1280" alt="screen shot 2017-12-04 at 10 10 07" src="https://user-images.githubusercontent.com/5403694/33546955-c3b26a98-d8e2-11e7-9db9-3903639c67fe.png">

After some more improvements it could look like this, however I wasn't sure would you like it and didn't include it in this PR:

![dec-04-2017 10-44-53](https://user-images.githubusercontent.com/5403694/33546997-e48f1202-d8e2-11e7-871f-f7df954d7edd.gif)
