### PR TITLE
Add skylight gem for Skylight for Open Source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,3 +111,4 @@ gem 'redis-namespace'
 gem 'barnes', git: "https://github.com/heroku/barnes"
 gem 'stackprof'
 gem 'prawn'
+gem 'skylight'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,6 +320,8 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
+    skylight (1.5.0)
+      activesupport (>= 3.0.0)
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -434,6 +436,7 @@ DEPENDENCIES
   sidekiq
   simplecov
   sinatra
+  skylight
   slim-rails
   spring
   sprockets!


### PR DESCRIPTION
Hello, Code Triage maintainers! 

I'm writing on behalf of the team at [Skylight](https://www.skylight.io), and following up on a conversation between @schneems and @chancancode. As you've likely heard, our team is planning on making Skylight free for open source projects this year, and we wanted to offer you a free beta account to use Skylight on your Rails app for free!

We wanted to make this process as easy for you as possible, so this PR is the first step in that direction. It adds the `skylight` agent to the project's Gemfile. 

Once this is merged/deployed, you will just need to set an ENV variable containing your API key, which we can send you privately over DM. Until that variable is set, you will see a message like this in your application logs: `[SKYLIGHT] Unable to start, see the Skylight logs for more details`.  However, it won't prevent your app from running normally, and once your API key is set, the message will go away!

You will also eventually need to create [an account](https://www.skylight.io/signup) on Skylight so that you can see your app and dashboard once it is live.

Let me know if you have any questions, or if you run into any trouble along the way. I'm more than happy to help! 😄