### PR TITLE
Re-add space between static copy and repo name

### DIFF
--- a/app/views/subscribers/show.html.slim
+++ b/app/views/subscribers/show.html.slim
@@ -3,8 +3,7 @@ div class="subpage-content-wrapper #{ @repo.weight }"
     h1.subpage-primary-title #{ @repo.subscribers_count } #{ @repo.name } Subscribers
     .subpage-header-actions
       = link_to @repo, class: "header-primary-action"
-        | Back to
-        = @repo.name
+        | Back to #{@repo.name}
 
   ul.avatars-list = render 'avatars', subscribers: @subscribers, show_names: true
   = will_paginate @subscribers


### PR DESCRIPTION
Looks like your editor chomped off a space in 49b243f1a295ecb19b4e2efa75aa38bd6ec5e2bf