### PR TITLE
The “last” subscription may not have any issues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -136,7 +136,7 @@ class User < ActiveRecord::Base
   end
 
   def days_since_last_email
-    last_sent_at = repo_subscriptions.last.try(:last_sent_at)
+    last_sent_at = repo_subscriptions.where("last_sent_at is not null").order(:last_sent_at).first.try(:last_sent_at)
     last_sent_at ||= self.created_at
     (
       (Time.now - last_sent_at) / 1.day


### PR DESCRIPTION
This should be more representative of actual activity.