### PR TITLE
Don't show repos in "Repos that need help" section when user is subscribed

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,6 +23,7 @@ class PagesController < ApplicationController
     if (language = valid_params[:language] || current_user.try(:favorite_languages))
       @repos = @repos.where(language: language)
     end
+    @repos = @repos.without_user_subscriptions(current_user.id) if user_signed_in?
     @repos = @repos.order_by_issue_count.page(valid_params[:page]).per_page(valid_params[:per_page] || 50)
 
     if user_signed_in?

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -164,8 +164,8 @@ class Repo < ActiveRecord::Base
   end
 
   def self.without_user_subscriptions(user_id)
-    user_subscribed_repos = RepoSubscription.where(user_id: user_id).select(:repo_id)
-    self.where('id not in (?)', user_subscribed_repos)
+    user_subscribed_repo_ids = RepoSubscription.where(user_id: user_id).select(:repo_id)
+    self.where.not(id: user_subscribed_repo_ids)
   end
 
   def github_url

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -163,6 +163,11 @@ class Repo < ActiveRecord::Base
     self.where("issues_count > 0")
   end
 
+  def self.without_user_subscriptions(user_id)
+    user_subscribed_repos = RepoSubscription.where(user_id: user_id).select(:repo_id)
+    self.where('id not in (?)', user_subscribed_repos)
+  end
+
   def github_url
     File.join('https://github.com', full_name)
   end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -116,4 +116,14 @@ class RepoTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test '.without_user_subscriptions' do
+    user = users(:schneems)
+    subscribed_repo = user.repo_subscriptions.first
+    unsubscribed_repo = repos(:sinatra_sinatra)
+
+    repos = Repo.without_user_subscriptions(user.id).to_a
+    assert_not repos.include?(subscribed_repo)
+    assert repos.include?(unsubscribed_repo)
+  end
 end


### PR DESCRIPTION
Hi,

I thought it would be useful to hide repos that a user is subscribed to from the "projects that need help" section so that they don't show up more than once on the user's dashboard when they are logged in.

### Current Behavior

As a user who is subscribed to Repo X, when I am logged in to the home page I see Repo X in the "Repos you are currently helping" section as well as in the "Open Source projects that need your help" section.

### Expected Behavior

As a user who is subscribed to Repo X,  when I am logged in I only see Repo X in the "Repos you are currently helping" section.

This PR is a working example.  Let me know if you think this is useful and I can finish it up and add tests.  I'm also open to any other feedback on implementation, code style, etc.

Thanks! 
