### PR TITLE
Add performance monitoring badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## CodeTriage
 
 [![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=master)](http://travis-ci.org/codetriage/codetriage)
+[![View performance data on Skylight](https://badges.skylight.io/status/IfSk4kDAh56r.svg)](https://oss.skylight.io/app/applications/IfSk4kDAh56r)
 [![Code Helpers Badge](https://www.codetriage.com/codetriage/codetriage/badges/users.svg)](https://codetriage.com/codetriage/codetriage)
 
 ## What is Triage?


### PR DESCRIPTION
[Preview this change](https://github.com/chancancode/codetriage/blob/73de5ae0d357ae94a96cae30eacdeba012b7b276/README.md)

<img width="1119" alt="skylight-2" src="https://user-images.githubusercontent.com/55829/37967115-49e39d20-31c2-11e8-8bd6-2275fcd048e0.png">

I finally figured out why Skylight wasn't working! Turns out, an old ENV var from 2013 was shadowing the token we are trying to set 😄 

Now that it is working, this will link to the public (no login needed) performance dashboard to help contributors find it. (Plus it will turn grey if this stops working again.)
