### PR TITLE
Cache the description meta tag

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,7 +16,7 @@ class PagesController < ApplicationController
 
   def index
     set_title("Get Started Contributing to Open Source Projects")
-    set_description("Discover the easiest way to get started contributing to open source. Over #{number_with_delimiter(cached_user_count, delimiter: ',')} devs are helping #{number_with_delimiter(cached_repo_count, delimiter: ',')} projects with our free, community developed tools")
+    set_description(description)
 
     @repos = Repo.with_some_issues
                  .select(:id, :updated_at, :issues_count, :language, :full_name, :name, :description)
@@ -39,12 +39,13 @@ class PagesController < ApplicationController
     end
   end
 
-  private def cached_repo_count
-    @@cached_repo_count ||= Repo.count
-  end
-
-  private def cached_user_count
-    @cached_user_count ||= User.count
+  private def description
+    Rails.cache.fetch("pages#index/description", expires_in: 1.hour) do
+      "Discover the easiest way to get started contributing to open source. " \
+      "Over #{number_with_delimiter(User.count, delimiter: ',')} devs are " \
+      "helping #{number_with_delimiter(Repo.count, delimiter: ',')} projects " \
+      "with our free, community developed tools"
+    end
   end
 
   def valid_params


### PR DESCRIPTION
Before this change, we were doing two queries per request to get the count of users and repos to generate the description meta tag (see screenshot below). Presumably, we don't actually care that these numbers are super up-to-date, so we can cache it up to an hour (same as the similar text in the [template's h2 tag](https://github.com/codetriage/codetriage/blob/633948dad71f072712dc322c514142f7df2f2a25/app/views/pages/index.html.slim#L3)).

[![screen shot 2018-04-10 at 4 13 20 pm](https://user-images.githubusercontent.com/6921610/38588351-3e3ccd98-3cda-11e8-8848-883794bf2215.png)](https://oss.skylight.io/app/applications/IfSk4kDAh56r/1523380440/6h/endpoints/PagesController%23index?responseType=html)
