### PR TITLE
Fix caching

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -39,7 +39,9 @@ class PagesController < ApplicationController
     end
   end
 
-  private def description
+  private
+
+  def description
     Rails.cache.fetch("pages#index/description", expires_in: 1.hour) do
       "Discover the easiest way to get started contributing to open source. " \
       "Over #{number_with_delimiter(User.count, delimiter: ',')} devs are " \
@@ -51,8 +53,6 @@ class PagesController < ApplicationController
   def valid_params
     params.permit(:language, :per_page, :page)
   end
-
-  private
 
   def set_cache_headers
     response.headers["Cache-Control"] = "no-cache, no-store"

--- a/app/views/repos/_repo.html.slim
+++ b/app/views/repos/_repo.html.slim
@@ -1,15 +1,14 @@
-= cache repo do
-  li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.language }"
-    = link_to repo
-      header.repo-item-header
-        h4.repo-item-title = repo.name
-        span.repo-item-issues
-          span.warning-svg.issue-icon
-          = repo.issues_count
-          |  Issues
+li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.language }"
+  = link_to repo
+    header.repo-item-header
+      h4.repo-item-title = repo.name
+      span.repo-item-issues
+        span.warning-svg.issue-icon
+        = repo.issues_count
+        |  Issues
 
-      p.repo-item-description = repo.description
+    p.repo-item-description = repo.description
 
-      - if repo.full_name.present?
-        span.repo-item-full-name
-          | (#{repo.full_name})
+    - if repo.full_name.present?
+      span.repo-item-full-name
+        | (#{repo.full_name})


### PR DESCRIPTION
We noticed this problem recently:

<img width="1679" alt="skylight-8" src="https://user-images.githubusercontent.com/55829/39012214-ca176c16-43e1-11e8-80b1-c3d392133c1c.png">

When rendering the repo "cards" on the homepage, we use the collection caching feature to avoid multiple roundtrips to the cache store (the "cache read multi" in Skylight). However, when there are cache misses, we end up doing another separate read/write to the cache store per card, and then we do another write at the end from the collection caching.

You can see this in the logs as well:

```
Cache read_multi: ["views/repos/1894-20180413141703167092/b201d971de1a77b9f19a62934e479a96", "views/repos/1245-20180413141214948480/b201d971de1a77b9f19a62934e479a96", "views/repos/3353-20180413142449772302/b201d971de1a77b9f19a62934e479a96", "views/repos/987-20180413140921805080/b201d971de1a77b9f19a62934e479a96", "views/repos/1240-20180413141121053193/b201d971de1a77b9f19a62934e479a96", "views/repos/2193-20180413141853545411/b201d971de1a77b9f19a62934e479a96", "views/repos/1055-20180413141006040871/b201d971de1a77b9f19a62934e479a96", "views/repos/1332-20180413141232839666/b201d971de1a77b9f19a62934e479a96", "views/repos/1258-20180413141035528117/b201d971de1a77b9f19a62934e479a96", "views/repos/3400-20180413142527911773/b201d971de1a77b9f19a62934e479a96", "views/repos/1967-20180413141718992348/b201d971de1a77b9f19a62934e479a96", "views/repos/2151-20180413141907871737/b201d971de1a77b9f19a62934e479a96", "views/repos/1082-20180413140958427040/Cache read: views/repos/3353-20180413142449772302/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3353-20180413142449772302/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1055-20180413141006040871/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1055-20180413141006040871/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1332-20180413141232839666/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1332-20180413141232839666/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/2151-20180413141907871737/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2151-20180413141907871737/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1082-20180413140958427040/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1082-20180413140958427040/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1524-20180413141412726203/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1524-20180413141412726203/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1916-20180413141546875915/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1916-20180413141546875915/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1348-20180413141215739127/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1348-20180413141215739127/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/177-20180413140322053324/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/177-20180413140322053324/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1824-20180413141520630598/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1824-20180413141520630598/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1901-20180413141634501842/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1901-20180413141634501842/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/863-20180413140900779427/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/863-20180413140900779427/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/386-20180413140542430556/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/386-20180413140542430556/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1996-20180413141654477686/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1996-20180413141654477686/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/528-20180413140609506027/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/528-20180413140609506027/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/3072-20180413142336550445/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3072-20180413142336550445/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1421-20180413141154176342/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1421-20180413141154176342/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/2216-20180413141847819637/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2216-20180413141847819637/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/3916-20180413142706315602/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3916-20180413142706315602/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/3793-20180413142632521852/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3793-20180413142632521852/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/696-20180413140702557180/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/696-20180413140702557180/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1521-20180413141315869506/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1521-20180413141315869506/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/781-20180413140752378480/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/781-20180413140752378480/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/297-20180413140459380343/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/297-20180413140459380343/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/764-20180413140728504164/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/764-20180413140728504164/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/2188-20180413141834504728/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2188-20180413141834504728/b201d971de1a77b9f19a62934e479a96
Cache read: views/repos/1224-20180413141032106598/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1224-20180413141032106598/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3353-20180413142449772302/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1055-20180413141006040871/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1332-20180413141232839666/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2151-20180413141907871737/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1082-20180413140958427040/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1524-20180413141412726203/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1916-20180413141546875915/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1348-20180413141215739127/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/177-20180413140322053324/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1824-20180413141520630598/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1901-20180413141634501842/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/863-20180413140900779427/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/386-20180413140542430556/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1996-20180413141654477686/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/528-20180413140609506027/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3072-20180413142336550445/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1421-20180413141154176342/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2216-20180413141847819637/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3916-20180413142706315602/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/3793-20180413142632521852/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/696-20180413140702557180/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1521-20180413141315869506/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/781-20180413140752378480/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/297-20180413140459380343/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/764-20180413140728504164/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/2188-20180413141834504728/b201d971de1a77b9f19a62934e479a96
Cache write: views/repos/1224-20180413141032106598/b201d971de1a77b9f19a62934e479a96
  Rendered collection of repos/_repo.html.slim [23 / 50 cache hits] (135.1ms)
```

This PR fixes the issue. We are working on the Rails side to make the inner `cache` block a no-op, but since we only ever use the repo partial as part of a collection, we can avoid the problem but removing the inner cache block for now.

We expect this patch to completely eliminate the "cache read" block shown in the Skylight screenshot above, and cut the "cache write" block by (roughly) half.