### PR TITLE
Clarify in README that PostgreSQL is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ $ bundle install
 ```
 
 ### Database
-* Create a database (default is PostgreSQL)
 * Copy database.yml and if you need, setup your own database credentials
+* Create database (you must use PostgreSQL)
 * Run migrations
 
 ```shell


### PR DESCRIPTION
Clarify that Postgres is required, not just recommended. For instance, CodeTriage has Postgres-specific migrations like 20151214120117 (EnablePgStatExtension).