### PR TITLE
Introduce Streaks model of counting interaction

### DIFF
--- a/app/controllers/doc_methods_controller.rb
+++ b/app/controllers/doc_methods_controller.rb
@@ -21,6 +21,7 @@ class DocMethodsController < ApplicationController
     assignment = DocAssignment.where(doc_method_id: doc.id, repo_subscription_id: sub.id).first
 
     if assignment&.user&.id.to_s == params[:user_id]
+      user.record_click!
       assignment.update_attributes(clicked: true)
       assignment.user.update_attributes(last_clicked_at: Time.now)
       redirect_to doc_method_url(doc)
@@ -38,6 +39,7 @@ class DocMethodsController < ApplicationController
     assignment = DocAssignment.find_by!(doc_method_id: doc.id, repo_subscription_id: sub.id)
 
     if assignment.user.id.to_s == params[:user_id]
+      user.record_click!
       assignment.update_attributes(clicked: true)
       assignment.user.update_attributes(last_clicked_at: Time.now)
       redirect_to doc.to_github

--- a/app/controllers/issue_assignments_controller.rb
+++ b/app/controllers/issue_assignments_controller.rb
@@ -9,6 +9,7 @@ class IssueAssignmentsController < ApplicationController
   def click_issue_redirect
     assignment = IssueAssignment.find(params[:id])
     if assignment&.user&.id.to_s == params[:user_id]
+      user.record_click!
       assignment.update_attributes(clicked: true)
       assignment.user.update_attributes(last_clicked_at: Time.now)
       redirect_to assignment.issue.html_url

--- a/app/models/email_rate_limit.rb
+++ b/app/models/email_rate_limit.rb
@@ -3,7 +3,13 @@
 # last day we sent them an email. The idea is that we should send more active users
 # more emails. Less active users should get fewer emails so that it's less annoying.
 class EmailRateLimit
-  USER_STATES = ["daily", "twice_a_week", "once_a_week", "once_a_month"]
+  # USER_STATES = ["daily", "twice_a_week", "once_a_week", "once_a_month"]
+  USER_STATES_HASH = {}
+  USER_STATES_HASH["daily"]        = "Daily"
+  USER_STATES_HASH["twice_a_week"] = "Twice a week"
+  USER_STATES_HASH["once_a_week"]  = "Once a week"
+  USER_STATES_HASH["once_a_month"] = "Once a month"
+  USER_STATES = USER_STATES_HASH.keys
 
   def initialize(last_clicked_days_ago, minimum_frequency: nil)
     @last_clicked_days_ago = last_clicked_days_ago

--- a/app/models/mail_builder/grouped_issues_docs.rb
+++ b/app/models/mail_builder/grouped_issues_docs.rb
@@ -186,10 +186,10 @@ module MailBuilder
     alias :any_docs?   :any_docs
     alias :any_issues? :any_issues
 
-    def actions
+    def actions(delimiter: "and")
       return "issues" if !self.any_docs
       return "docs"   if !self.any_issues
-      "issues and docs"
+      "issues #{delimiter} docs"
     end
 
     def comment_for_doc(doc)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ActiveRecord::Base
   end
 
   # The `raw_streak_count` is the value stored in the
-  # DB. This value is only updated when a user clicks on an
+  # DB. This value should be updated when a user clicks on an
   # email.
   #
   # The `emails_missed_since_click` is updated every time

--- a/app/views/user_mailer/send_daily_triage.md.erb
+++ b/app/views/user_mailer/send_daily_triage.md.erb
@@ -1,10 +1,18 @@
 Hello @<%= @user.github %>,
 
-<% if @days > @max_days %>
-  It's been [<%= @days %> days] since you've clicked on a CodeTriage.com link, let's keep those issue counts down.
+<% case @user.effective_streak_count %>
+<% when 0 %>
+  Welcome! To get your contribution streak started click on a <%=  @grouped_issues_docs.actions(delimiter: "or") %> link below. Your goal is to observe and learn. Read the contents and try to pick out patterns. Keep clicking on links and learning to build up your streak. When it comes to contribution, consistency is key.
+<% when 1..10 %>
+  Your contribution streak is at <%= @user.effective_streak_count %>. Click on a <%=  @grouped_issues_docs.actions(delimiter: "or") %> link below to keep going. The goal is still to learn. Start taking notes on what you observe, how is it different today than what you saw from the last email? How is it the same?
+<% else %>
+  Your contribution streak is at <%= @user.effective_streak_count %>. Keep clicking to keep it growing.
 <% end %>
 
-Here are some <%= @grouped_issues_docs.actions %> you should check out:
+<% case @user.effective_streak_count %>
+<% when 2..5 %>
+  If you miss an email you won't lose everything, but your streak count will go down by one. If that's too much pressure and you need some more time between emails, you can [change your email frequency](<%= edit_user_url(@user) %>). You can also access this page at any time by logging in on CodeTriage.
+<% end %>
 
 <% @grouped_issues_docs.each do |group| %>
 

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -10,8 +10,16 @@
     .input-preprend
       span.add-on
         i.icon-envelope
-      = f.select :email_frequency, options_for_select( EmailRateLimit::USER_STATES.map {|value| [ value.humanize, value ] }, f.object.email_frequency), class: 'select'
-      p When you're busy we try to send you less emails, if that's not good enough set your frequency here. For example if you set "twice a week" you won't receive more than 2 emails a week.
+      = f.select :email_frequency, options_for_select( EmailRateLimit::USER_STATES_HASH.map {|key, name| [ name, key ] }, f.object.email_frequency), class: 'select'
+      p When you're busy we try to send you fewer emails, if that's not good enough set your desired frequency here. For example if you set "twice a week" you won't receive more than 2 emails a week.
+      p How often should you get emails? It depends on your goals:
+      ul.bullets
+        li <strong>Daily:</strong><i> "I want to ramp up as fast as possible, I'm working towards becoming a committer ASAP."</i>
+        li <strong>Twice a week:</strong></i> "Being a committer is still in my sights, but it doesn't need to be tomorrow."</i>
+        li <strong>Once a week:</strong><i> "I might be a committer one day, but for now I only want to help out here and there."</i>
+        li <strong>Once a month:</strong> <i>"I want to see casually what's going on and I want to help a tiny bit."</i>
+      br
+      p The most important thing is consistency. No matter the frequency you can commit to, keep clicking on issues, keep learning, and you'll get there!
 
   = f.label :email_time_of_day, t("activerecord.attributes.user.email_time_of_day", default: "Email time of day"), class: "label label-info"
   .controls

--- a/db/migrate/20180716144937_add_streak_to_users.rb
+++ b/db/migrate/20180716144937_add_streak_to_users.rb
@@ -1,0 +1,6 @@
+class AddStreakToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :raw_streak_count, :integer, default: 0
+    add_column :users, :raw_emails_since_click, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171125212307) do
+ActiveRecord::Schema.define(version: 2018_07_16_144937) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
+  enable_extension "plpgsql"
 
   create_table "data_dumps", id: :serial, force: :cascade do |t|
     t.text "data"
@@ -73,6 +73,15 @@ ActiveRecord::Schema.define(version: 20171125212307) do
     t.index ["repo_id"], name: "index_doc_methods_on_repo_id"
   end
 
+  create_table "email_records", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "streak_count", default: 0
+    t.boolean "was_clicked", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_email_records_on_user_id"
+  end
+
   create_table "issue_assignments", id: :serial, force: :cascade do |t|
     t.integer "issue_id"
     t.datetime "created_at"
@@ -103,6 +112,28 @@ ActiveRecord::Schema.define(version: 20171125212307) do
     t.index ["repo_id", "number"], name: "index_issues_on_repo_id_and_number"
     t.index ["repo_id"], name: "index_issues_on_repo_id"
     t.index ["state"], name: "index_issues_on_state"
+  end
+
+  create_table "opro_auth_grants", id: :serial, force: :cascade do |t|
+    t.string "code", limit: 255
+    t.string "access_token", limit: 255
+    t.string "refresh_token", limit: 255
+    t.text "permissions"
+    t.datetime "access_token_expires_at"
+    t.integer "user_id"
+    t.integer "application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "opro_client_apps", id: :serial, force: :cascade do |t|
+    t.string "name", limit: 255
+    t.string "app_id", limit: 255
+    t.string "app_secret", limit: 255
+    t.text "permissions"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "repo_subscriptions", id: :serial, force: :cascade do |t|
@@ -172,12 +203,15 @@ ActiveRecord::Schema.define(version: 20171125212307) do
     t.string "email_frequency", default: "daily"
     t.time "email_time_of_day"
     t.string "old_token"
+    t.integer "raw_streak_count", default: 0
+    t.integer "raw_emails_since_click", default: 0
     t.index ["account_delete_token"], name: "index_users_on_account_delete_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github"], name: "index_users_on_github", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "email_records", "users"
   add_foreign_key "repo_subscriptions", "repos"
   add_foreign_key "repo_subscriptions", "users"
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,6 +1,53 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
+  test 'streak tests' do
+    # New user, first email
+    user = User.new(github: "whatever1")
+    assert_equal 0, user.effective_streak_count
+
+    user.raw_emails_since_click = 1
+    assert_equal 0, user.effective_streak_count
+
+    # First email click
+    user.record_click!(save: false)
+    assert_equal 0, user.raw_emails_since_click
+    assert_equal 1, user.raw_streak_count
+    assert_equal 1, user.effective_streak_count
+
+    # Multiple clicks on same issue don't change
+    user.record_click!(save: false)
+    user.record_click!(save: false)
+    user.record_click!(save: false)
+    assert_equal 0, user.raw_emails_since_click
+    assert_equal 1, user.raw_streak_count
+    assert_equal 1, user.effective_streak_count
+
+    # 1 email sent since click
+    user = User.new(github: "whatever2")
+    user.raw_streak_count = 10
+    user.raw_emails_since_click = 1
+
+    assert_equal 10, user.effective_streak_count
+    user.record_click!(save: false)
+
+    assert_equal 0, user.raw_emails_since_click
+    assert_equal 11, user.raw_streak_count
+    assert_equal 11, user.effective_streak_count
+
+    # Two emails sent since click
+    user = User.new(github: "whatever3")
+    user.raw_streak_count = 10
+    user.raw_emails_since_click = 2
+
+    assert_equal 9, user.effective_streak_count
+    user.record_click!(save: false)
+
+    assert_equal 0, user.raw_emails_since_click
+    assert_equal 10, user.raw_streak_count
+    assert_equal 10, user.effective_streak_count
+  end
+
   test '#github_url returns github url' do
     github_url = User.new(github: 'jroes').github_url
     assert_equal 'https://github.com/jroes', github_url


### PR DESCRIPTION
The current method “days since you clicked” is a bad incentive. The number grows while you do the wrong thing and it gets set back to zero when you do the right thing (click an issue). Instead, we move to positive reinforcement. When the user clicks an issue they see the count incremented by one. When the miss clicking on an email, the count is decremented (so if someone takes a short break they don’t lose their entire streak, but if they go away entirely it will.

In the future, we can add some more semantic context around the number. For instance, we might give the user positive reinforcement when `emails_missed_since_click` is 0 (since that means they are active recently), and some negative reinforcement if this value is higher (indicating that their streak is going down). We might also want to encourage someone to decrease the rate of their emails if their streak count is falling rather than them being not-engaged or deleting their account.

Other ideas instead of simple increment/decrement are some kind of “levels” where people can hit achievements. We could also perhaps add badges. 

The best way to understand the logic is to look at the `user_test.rb`. Essentially the `raw_streak_count` is the last recorded streak value. Every time we send an email we increment the `raw_emails_since_click`. With these two numbers, we can calculate the `effective_streak_count` which is the value we show to the user. 

When a user clicks on a link then the `raw_streak_count` is set to the current effective streak count and then incremented (since they just clicked). We then reset the `raw_emails_since_click` counter to zero.

In the future, it might make sense to introduce some kind of an “email record” table to record what issues and docs went out on which email, but for now, all we need is to add these two numbers and we get a good amount of information.
