### PR TITLE
Shuffle order of issues in email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'faker', require: false
   gem 'pry'
-  gem 'rubocop', '0.49.1', require: false
+  gem 'rubocop', '0.58.2', require: false
   gem 'teaspoon'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     htmlentities (4.3.4)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1-x86_64-darwin-17)
     jmespath (1.3.1)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
@@ -223,7 +224,7 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     parallel (1.12.1)
-    parser (2.5.0.0)
+    parser (2.5.0.3)
       ast (~> 2.4.0)
     pdf-core (0.7.0)
     pg (0.18.3)
@@ -306,11 +307,12 @@ GEM
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
     rrrretry (1.0.0)
-    rubocop (0.49.1)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
@@ -458,7 +460,7 @@ DEPENDENCIES
   redis-namespace
   render_async (~> 1.1, >= 1.1.2)
   rrrretry
-  rubocop (= 0.49.1)
+  rubocop (= 0.58.2)
   sassc
   sassc-rails
   scout_apm (~> 2.3.x)

--- a/app/controllers/repo_based_controller.rb
+++ b/app/controllers/repo_based_controller.rb
@@ -1,11 +1,11 @@
 class RepoBasedController < ApplicationController
   protected
 
-    def name_from_params(options)
-      [options[:name], options[:format]].compact.join('.')
-    end
+  def name_from_params(options)
+    [options[:name], options[:format]].compact.join('.')
+  end
 
-    def find_repo(options)
-      Repo.find_by_full_name(options[:full_name].downcase)
-    end
+  def find_repo(options)
+    Repo.find_by_full_name(options[:full_name].downcase)
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -11,7 +11,7 @@ class UserMailer < ActionMailer::Base
       assignment_ids:,
       read_doc_ids: [],
       write_doc_ids: []
-  )
+    )
 
     user = User.find(user_id)
     return unless set_and_check_user(user)

--- a/app/models/mail_builder/grouped_issues_docs.rb
+++ b/app/models/mail_builder/grouped_issues_docs.rb
@@ -48,7 +48,7 @@ module MailBuilder
   # returns the subscription ID for that repo.
   #
   class GroupedIssuesDocs
-    def initialize(user_id:, assignment_ids: [], read_doc_ids: [], write_doc_ids: [])
+    def initialize(user_id:, assignment_ids: [], read_doc_ids: [], write_doc_ids: [], random_seed: Random.new_seed)
       @active            = false
       @sub_hashes        = {}
       @repo_id_to_sub    = {}
@@ -84,6 +84,8 @@ module MailBuilder
                        .where(user_id: user_id)
                        .select(:id, :repo_id)
                        .includes(:repo)
+                       .all
+                       .shuffle(random: Random.new(random_seed))
 
       store_subscriptions!(subscriptions)
       store_assignments!(assignments)
@@ -148,6 +150,7 @@ module MailBuilder
         @active_hash = @error_hash
       end
     end
+    include Enumerable
 
     def repo
       @active_hash[:repo]

--- a/app/models/mail_builder/grouped_issues_docs.rb
+++ b/app/models/mail_builder/grouped_issues_docs.rb
@@ -79,13 +79,13 @@ module MailBuilder
       doc_repo_ids = docs.map(&:repo_id).uniq
 
       subscriptions = RepoSubscription
-                       .joins("LEFT OUTER JOIN issue_assignments ON issue_assignments.repo_subscription_id = repo_subscriptions.id")
-                       .where("issue_assignments.id in (?) or repo_id in (?)", assignment_ids, doc_repo_ids)
-                       .where(user_id: user_id)
-                       .select(:id, :repo_id)
-                       .includes(:repo)
-                       .all
-                       .shuffle(random: Random.new(random_seed))
+                      .joins("LEFT OUTER JOIN issue_assignments ON issue_assignments.repo_subscription_id = repo_subscriptions.id")
+                      .where("issue_assignments.id in (?) or repo_id in (?)", assignment_ids, doc_repo_ids)
+                      .where(user_id: user_id)
+                      .select(:id, :repo_id)
+                      .includes(:repo)
+                      .all
+                      .shuffle(random: Random.new(random_seed))
 
       store_subscriptions!(subscriptions)
       store_assignments!(assignments)

--- a/app/models/mail_builder/grouped_issues_docs.rb
+++ b/app/models/mail_builder/grouped_issues_docs.rb
@@ -77,21 +77,13 @@ module MailBuilder
 
       ## Subscriptions
       doc_repo_ids = docs.map(&:repo_id).uniq
+
       subscriptions = RepoSubscription
-                      .where(user_id: user_id)
-                      .where(repo_id: doc_repo_ids)
-                      .includes(:repo)
-                      .select(:id, :repo_id)
-
-      subscriptions += RepoSubscription
-                       .joins(:issue_assignments)
-                       .where("issue_assignments.id" => assignment_ids)
+                       .joins("LEFT OUTER JOIN issue_assignments ON issue_assignments.repo_subscription_id = repo_subscriptions.id")
+                       .where("issue_assignments.id in (?) or repo_id in (?)", assignment_ids, doc_repo_ids)
                        .where(user_id: user_id)
-                       .where.not(repo_id: doc_repo_ids)
-                       .includes(:repo)
                        .select(:id, :repo_id)
-
-      subscriptions.uniq!
+                       .includes(:repo)
 
       store_subscriptions!(subscriptions)
       store_assignments!(assignments)

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -112,7 +112,9 @@ class Repo < ActiveRecord::Base
 
   # pulls out number of issues divided by number of subscribers
   def self.order_by_need
-    joins(:repo_subscriptions).order("issues_count::float/COUNT(repo_subscriptions.repo_id) DESC").group("repos.id")
+    joins(:repo_subscriptions)
+      .order(Arel.sql("issues_count::float/COUNT(repo_subscriptions.repo_id) DESC"))
+      .group("repos.id")
   end
 
   # these repos have no subscribers and have no buisness being in our database

--- a/test/emails/send_daily_triage_email_test.rb
+++ b/test/emails/send_daily_triage_email_test.rb
@@ -23,7 +23,7 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal 2, triage_email.parts.size
     assert_equal "multipart/alternative", triage_email.mime_type
 
-    assert_match /Help Triage 1 Open Source Issue/, triage_email.subject
+    assert_match /Help Triage \d+ Open Source Issue/, triage_email.subject
 
     # Repo groups
     assert_match /## bemurphy\/issue_triage_sandbox/, triage_email_text

--- a/test/fixtures/issue_assignments.yml
+++ b/test/fixtures/issue_assignments.yml
@@ -3,3 +3,16 @@
 one:
   repo_subscription: schneems_to_triage
   issue: issue_one
+
+schneems_triage_issue_assignment:
+  repo_subscription: schneems_to_triage
+  issue: issue_one
+
+schneems_sinatra_issue_assignment:
+  repo_subscription: schneems_to_sinatra
+  issue: issue_two
+
+two:
+  repo_subscription: jroes_to_rails
+  issue: issue_two
+

--- a/test/fixtures/repo_subscriptions.yml
+++ b/test/fixtures/repo_subscriptions.yml
@@ -7,6 +7,15 @@ schneems_to_triage:
   email_limit: 3
   write_limit: 1
 
+schneems_to_sinatra:
+  repo: sinatra_sinatra
+  user: schneems
+  created_at: 2013-10-29 21:09:48.351554000 Z
+  updated_at: 2013-10-29 21:09:48.351554000 Z
+  last_sent_at:
+  email_limit: 3
+  write_limit:
+
 jroes_to_rails:
   repo: rails_rails
   user: jroes

--- a/test/fixtures/repos.yml
+++ b/test/fixtures/repos.yml
@@ -26,6 +26,15 @@ sinatra_sinatra:
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 1
 
+no_subscribers:
+  user_name: no
+  name: subscribers
+  full_name: no/subscribers
+  language: ruby
+  created_at: 2012-11-10 21:50:48.351554000 Z
+  updated_at: 2012-11-10 21:50:48.351554000 Z
+  issues_count: 1
+
 node:
   user_name: joyent
   name: node

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -120,7 +120,7 @@ class RepoTest < ActiveSupport::TestCase
   test '.without_user_subscriptions' do
     user = users(:schneems)
     subscribed_repo = user.repo_subscriptions.first
-    unsubscribed_repo = repos(:sinatra_sinatra)
+    unsubscribed_repo = repos(:no_subscribers)
 
     repos = Repo.without_user_subscriptions(user.id).to_a
     assert_not repos.include?(subscribed_repo)


### PR DESCRIPTION
Right now all the issues that I get are in the same order every time. It’s a bit monotonous. I don’t want people always only clicking on the first one, or getting in the habit of scrolling past the first one etc.

In the future, we can do something a bit smarter. Perhaps we can order by reverse clicked time so the repos that are most interesting are at the top.

To make a change like that I would likely want to introduce an actual A/B testing framework to see if it changes people’s behaviors (i.e. more clicks etc.).

In general, Random seems to give people the impression that the algorithm is smarter than it really is. Any behavior we implement should be able to beat “random”, so this is a good baseline.