### PR TITLE
Add simple noscript message warning to enable JS

### DIFF
--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -1,3 +1,6 @@
+noscript
+  .alert.flash-error CodeTriage requires JavaScript, please enable it!
+
 .top-bar-red
 .top-bar-yellow
 .top-bar-green


### PR DESCRIPTION
This is a quick stab at a `<noscript>` message. I wasn't sure where you'd want the the tag to live, `_nav` seemed like a reasonable spot, but let me know if you'd prefer something else.

 Also I didn't know if you'd object to me essentially hijacking the flash message styling for this warning. It seems to fit well, but I'd understand if you wanted to do that styling differently.

How it should look:
<img width="711" alt="noscript-screenshot" src="https://user-images.githubusercontent.com/444766/43814200-11be3b38-9a97-11e8-81a3-c54aa99e1cdd.png">

A link to easily disable javascript in chrome dev tools in case it's not top of mind: https://stackoverflow.com/questions/13405383/how-to-disable-javascript-in-chrome-developer-tools