### PR TITLE
Address deprecation warning

### DIFF
--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -53,7 +53,7 @@ class RepoSubscription < ActiveRecord::Base
         .active
         .where("doc_methods.id not in (?)", pre_assigned_doc_method_ids)
         .where(skip_read: false)
-        .order("random()")
+        .order(Arel.sql("RANDOM()"))
         .limit(limit || DEFAULT_READ_LIMIT)
   end
 
@@ -62,7 +62,7 @@ class RepoSubscription < ActiveRecord::Base
         .active
         .where("doc_methods.id not in (?)", pre_assigned_doc_method_ids)
         .where(skip_write: false)
-        .order("random()")
+        .order(Arel.sql("RANDOM()"))
         .limit(limit || DEFAULT_WRITE_LIMIT)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User < ActiveRecord::Base
   end
 
   def subscribe_docs!
-    subscriptions = self.repo_subscriptions.order('RANDOM()').load
+    subscriptions = self.repo_subscriptions.order(Arel.sql('RANDOM()')).load
     DocMailerMaker.new(self, subscriptions) { |sub| sub.ready_for_next? }.deliver_later
   end
 

--- a/test/mailers/previews/user_preview.rb
+++ b/test/mailers/previews/user_preview.rb
@@ -14,7 +14,7 @@ class UserPreview < ActionMailer::Preview
 
   def send_triage_create
     user  = User.last
-    repo  = Repo.order("random()").first
+    repo  = Repo.order(Arel.sql("RANDOM()")).first
     issue = Issue.where(state: "open", repo_id: repo.id).where.not(number: nil).first!
     sub   = RepoSubscription.where(user_id: user.id, repo_id: repo.id).first_or_create!
     assignment = sub.issue_assignments.where(issue_id: issue.id).first_or_create!
@@ -23,7 +23,7 @@ class UserPreview < ActionMailer::Preview
 
   def send_triage
     user  = User.last
-    repo  = Repo.order("random()").first
+    repo  = Repo.order(Arel.sql("RANDOM()")).first
     issue = Issue.where(state: "open", repo_id: repo.id).where.not(number: nil).first!
     sub   = RepoSubscription.where(user_id: user.id, repo_id: repo.id).first_or_create!
     assignment = sub.issue_assignments.where(issue_id: issue.id).first_or_create!
@@ -31,11 +31,11 @@ class UserPreview < ActionMailer::Preview
   end
 
   def send_daily_triage_mixed
-    write_docs = DocMethod.order("RANDOM()").includes(:repo).missing_docs.first(rand(0..8))
-    read_docs  = DocMethod.order("RANDOM()").includes(:repo).with_docs.first(rand(0..8))
+    write_docs = DocMethod.order(Arel.sql("RANDOM()")).includes(:repo).missing_docs.first(rand(0..8))
+    read_docs  = DocMethod.order(Arel.sql("RANDOM()")).includes(:repo).with_docs.first(rand(0..8))
 
-    write_docs = DocMethod.order("RANDOM()").includes(:repo).first(rand(0..8)) if write_docs.blank?
-    read_docs  = DocMethod.order("RANDOM()").includes(:repo).first(rand(0..8)) if read_docs.blank?
+    write_docs = DocMethod.order(Arel.sql("RANDOM()")).includes(:repo).first(rand(0..8)) if write_docs.blank?
+    read_docs  = DocMethod.order(Arel.sql("RANDOM()")).includes(:repo).first(rand(0..8)) if read_docs.blank?
 
     user        = User.last
     assignments = []
@@ -80,7 +80,7 @@ class UserPreview < ActionMailer::Preview
       issue = Issue
               .where(state: "open")
               .where.not(number: nil)
-              .order("RANDOM()")
+              .order(Arel.sql("RANDOM()"))
               .first
 
       next if issue.nil?
@@ -104,11 +104,11 @@ class UserPreview < ActionMailer::Preview
   def daily_docs
     user       = User.last
 
-    write_docs = DocMethod.order("RANDOM()").missing_docs.first(rand(0..8))
-    read_docs  = DocMethod.order("RANDOM()").with_docs.first(rand(0..8))
+    write_docs = DocMethod.order(Arel.sql("RANDOM()")).missing_docs.first(rand(0..8))
+    read_docs  = DocMethod.order(Arel.sql("RANDOM()")).with_docs.first(rand(0..8))
 
-    write_docs = DocMethod.order("RANDOM()").first(rand(0..8)) if write_docs.blank?
-    read_docs  = DocMethod.order("RANDOM()").first(rand(0..8)) if read_docs.blank?
+    write_docs = DocMethod.order(Arel.sql("RANDOM()")).first(rand(0..8)) if write_docs.blank?
+    read_docs  = DocMethod.order(Arel.sql("RANDOM()")).first(rand(0..8)) if read_docs.blank?
 
     ::UserMailer.daily_docs(
       user:       user,


### PR DESCRIPTION
The warning says:

>   DEPRECATION WARNING: Dangerous query method (method whose arguments
>   are used as raw SQL) called with non-attribute argument(s): "random()".
>   Non-attribute arguments will be disallowed in Rails 6.0. This method
>   should not be called with user-provided values, such as request
>   parameters or model attributes. Known-safe values can be passed by
>   wrapping them in Arel.sql().

There's currently only one deprecation warning in the test suite, but it
seems like a fairly straightforward change to make throughout as there
was no user input being used, just plain RANDOM() calls.