### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,8 +98,13 @@ Layout/SpaceInLambdaLiteral:
 Layout/SpaceInsideBlockBraces:
  Enabled: true
 
-Layout/SpaceInsideBrackets:
- Enabled: true
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+  AutoCorrect: true
+
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: true
+  AutoCorrect: true
 
 Layout/SpaceInsideHashLiteralBraces:
  Enabled: true
@@ -116,10 +121,10 @@ Layout/TrailingBlankLines:
 Layout/TrailingWhitespace:
  Enabled: true
 
-Lint/AssignmentInCondition:
+Layout/EndAlignment:
  Enabled: true
 
-Lint/EndAlignment:
+Lint/AssignmentInCondition:
  Enabled: true
 
 Lint/ScriptPermission:


### PR DESCRIPTION
**Rubocop output in test runs:**
>.rubocop.yml: Lint/EndAlignment has the wrong namespace - should be Layout
   * namespace chaged from Lint -> Layout
> Warning: unrecognized cop Layout/SpaceInsideBrackets found in .rubocop.yml
   * cop was deprecated and split into two separate cops:
     `Layout/SpaceInsideReferenceBrackets` and `Layout/SpaceInsideArrayLiteralBrackets.
     Functionality should be the same as previous cop.

References:
 * https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-9
 * https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutspaceinsidereferencebrackets
 * https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutspaceinsidearrayliteralbrackets