### PR TITLE
Sort the select options after converting to local time

### DIFF
--- a/app/assets/javascripts/user_email_time_of_day.js
+++ b/app/assets/javascripts/user_email_time_of_day.js
@@ -9,4 +9,11 @@ $(document).ready(function(){
       element.text = LocalTime.strftime(time, "%H:%M %Z");
     })
 
+  $("#user_email_time_of_day").html($("#user_email_time_of_day option").sort(function (a, b) {
+    return a.text == b.text ? 0 : a.text < b.text ? -1 : 1
+  }))
+
+  var after_work = $("#user_email_time_of_day").find("option:contains('19:00')").val()
+  $("#user_email_time_of_day").val(after_work)
+
 });


### PR DESCRIPTION
The current implentation leaves the original order (UTC) but just
changes the labels so it appears out of order to the user. The
proposed change is not amazing code, but seem effective to order based
on the user's local time.

Advantages: quick, easy, effective
Disadvantages: not the prettiest code, breaks handlers I believe (but
there are none that I see)

I thought this might be a good time to pick a time as the default. It
seems unlikely that midnight UTC is many people's first choice, so I
figured after work-ish (7PM local) would be a reasonable default.

References:
 - jquery select sort: https://stackoverflow.com/a/7466196

Resolves #721.