### PR TITLE
Update formatting for branch names

### DIFF
--- a/app/controllers/doc_methods_controller.rb
+++ b/app/controllers/doc_methods_controller.rb
@@ -6,10 +6,8 @@ class DocMethodsController < ApplicationController
                         .first
     @comment = @doc.doc_comments.select(:comment).first
     @repo    = @doc.repo
-
-    # http://stackoverflow.com/questions/3651860/which-characters-are-illegal-within-a-branch-name
     @username = current_user.present? ? current_user.github : "<your name>"
-    @branch   = "#{@username}/update-docs-#{@doc.path}-for-pr".gsub(/:|~|\^|\\|\.\./, "_")
+    @branch   = GitBranchnameGenerator.new(username: @username, doc_path: @doc.path)
 
     set_title("Help Writing docs #{@doc.path} - #{@repo.full_name} #{@repo.language}")
     set_description("#{@doc.missing_docs? ? 'Write' : 'Read'} docs for #{@repo.name} starting with #{@doc.path}.")

--- a/app/models/git_branchname_generator.rb
+++ b/app/models/git_branchname_generator.rb
@@ -1,0 +1,11 @@
+# http://stackoverflow.com/questions/3651860/which-characters-are-illegal-within-a-branch-name
+class GitBranchnameGenerator
+  def initialize(username:, doc_path:)
+    @username = username
+    @doc_path = doc_path
+  end
+
+  def branchname
+    "#{@username}-update-docs-#{@doc_path}-for-pr".gsub(/[^a-zA-Z0-9\_]/, "-")
+  end
+end

--- a/test/unit/git_branchname_generator_test.rb
+++ b/test/unit/git_branchname_generator_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class GitBranchnameGeneratorTest < ActiveSupport::TestCase
+  test "replaces non alpha-numerics and underscores with dashes" do
+    doc_path = "Pay-)(*&^%$#@!~ment.charge?"
+    assert_equal "username-update-docs-Pay------------ment-charge--for-pr",
+                 GitBranchnameGenerator.new(username: "username", doc_path: doc_path).branchname
+  end
+
+  test "does not allow pounds (#)" do
+    doc_path = "Payment#charge?"
+    assert_equal "username-update-docs-Payment-charge--for-pr",
+                 GitBranchnameGenerator.new(username: "username", doc_path: doc_path).branchname
+  end
+
+  test "does not allow periods" do
+    doc_path = "Payment.charge?"
+    assert_equal "username-update-docs-Payment-charge--for-pr",
+                 GitBranchnameGenerator.new(username: "username", doc_path: doc_path).branchname
+  end
+end


### PR DESCRIPTION
Resolves #688 which reports an issue when there is a question mark in the
method name. git spec states that question marks are not allowed. I took
more conservative approach and only allowed numbers, letters, and
underscores.

I also converted periods to pounds:
  `Payment.charge` -> `Payment#charge`