### PR TITLE
Revert default email time of day selection

### DIFF
--- a/app/assets/javascripts/user_email_time_of_day.js
+++ b/app/assets/javascripts/user_email_time_of_day.js
@@ -13,7 +13,4 @@ $(document).ready(function(){
     return a.text == b.text ? 0 : a.text < b.text ? -1 : 1
   }))
 
-  var after_work = $("#user_email_time_of_day").find("option:contains('19:00')").val()
-  $("#user_email_time_of_day").val(after_work)
-
 });


### PR DESCRIPTION
* I introduced a bug in the way that I selected the email time of day
because I was ALWAYS selecting the default time instead of only when the
user hadn't selected a date.

* There are a number of ways to do this, but it's not something anyone
asked for (or that anyone probably needs). No code being better than
more code let's just remove it for now?