### PR TITLE
Force repo show page to invalidate cache

### DIFF
--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -6,7 +6,7 @@ class RepoSubscription < ActiveRecord::Base
   validates  :user_id, presence: true
   validates  :email_limit, numericality: { less_than: 21, greater_than_or_equal_to: 0 }
 
-  belongs_to :repo, counter_cache: :subscribers_count
+  belongs_to :repo, counter_cache: :subscribers_count, touch: true
   belongs_to :user
 
   has_many   :issue_assignments


### PR DESCRIPTION
I'll start this by saying that caching in rails is NOT a strength of mine. I figured solving this issue would give me the chance to get a bit smarter on the matter. Fortunately/unfortunately I got it to work sooner than I thought.

Fortunately: it seems to work.
Unfortunately: I feel like it was too easy so I'm afraid it's not correct 😄.

As you see, all I did was add `touch: true` in `RepoSubscription` on the `belongs_to: repo` association.

The obvious thing I could have messed up was just testing it incorrectly in dev mode, but I did set `rails dev:cache` (thanks rails, that's quite nice). So I think I got that part right. I manually tested this by subscribing/unsubscribing after setting the cache mode in dev with and without the `touch: true` beings set so I _think_ it works, but I lack full confidence in this area so take a second look at this one please! 😄 

I'm happy to keep reading on caching if this is not the right approach or if this has some side effect I'm not aware of...