### PR TITLE
accessibility improvement: Add text to logo

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -65,3 +65,20 @@ blockquote {
 textarea.single-line {
   height: 3.25rem;
 }
+
+/*
+ * Taken from bourbon version 5.1.0 to allow for providing text to screen readers but hiding for visual users.
+ * This should be removed when bourbon is upgraded.
+ * https://github.com/thoughtbot/bourbon/blob/v5.1.0/core/bourbon/library/_hide-visually.scss
+*/
+.hide-visually {
+    border: 0;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(100%);
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}

--- a/app/views/application/_nav.html.slim
+++ b/app/views/application/_nav.html.slim
@@ -21,3 +21,4 @@ nav.application-navigation
 div.application-logo
   = link_to root_path
     span.application-logo-image
+    span.hide-visually Code Triage Home


### PR DESCRIPTION
Visually you shouldn't see a difference, but a screen reader will now tell the user that the link is to "Code Triage Home". I think that will be an improvement.

 * Style taken from bourbon version 5.1.0 to allow for providing text to screen readers but hiding for visual users. This should be removed when bourbon is upgraded.
   https://github.com/thoughtbot/bourbon/blob/v5.1.0/core/bourbon/library/_hide-visually.scss