### PR TITLE
accessibility enhancement: hierarchical heading tags

### DIFF
--- a/app/views/repos/_repo.html.slim
+++ b/app/views/repos/_repo.html.slim
@@ -1,7 +1,7 @@
 li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.language }"
   = link_to repo
     header.repo-item-header
-      h4.repo-item-title = repo.name
+      h3.repo-item-title = repo.name
       span.repo-item-issues
         span.warning-svg.issue-icon
         = repo.issues_count


### PR DESCRIPTION
Update heading tags to be hierarchical. `h4` -> `h3`. The styling looks the same to me visually and now the page structure will not skip the h3 tags.