### PR TITLE
[close #744] Make streak count update idempotent

### DIFF
--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -37,8 +37,10 @@ class SendDailyTriageEmailJob < ApplicationJob
       user_id:        user.id,
       assignment_ids: assignments.pluck(:id),
       write_doc_ids:  docs.write_docs.map(&:id),
-      read_doc_ids:   docs.read_docs.map(&:id)
+      read_doc_ids:   docs.read_docs.map(&:id),
+      email_at:       Time.now.iso8601
     ).deliver_later
+
     assignments.update_all(delivered: true)
     user.repo_subscriptions.update_all(last_sent_at: Time.now)
     mail

--- a/db/migrate/20180820155654_add_last_email_at_to_user.rb
+++ b/db/migrate/20180820155654_add_last_email_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddLastEmailAtToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :last_email_at, :datetime, default: "now()"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_16_144937) do
+ActiveRecord::Schema.define(version: 2018_08_20_155654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 2018_07_16_144937) do
     t.string "old_token"
     t.integer "raw_streak_count", default: 0
     t.integer "raw_emails_since_click", default: 0
+    t.datetime "last_email_at"
     t.index ["account_delete_token"], name: "index_users_on_account_delete_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github"], name: "index_users_on_github", unique: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,6 +11,7 @@ mockstar:
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   zip:
   phone_number:
   twitter:
@@ -37,6 +38,7 @@ foo_user:
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   zip:
   phone_number:
   twitter:
@@ -62,6 +64,7 @@ bar_user:
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   zip:
   phone_number:
   twitter:
@@ -87,6 +90,7 @@ schneems:
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   zip:
   phone_number:
   twitter:
@@ -111,6 +115,7 @@ jroes:
   current_sign_in_ip: 68.5.230.247
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
   zip:
   phone_number:
@@ -136,6 +141,7 @@ empty:
   current_sign_in_ip: 68.5.230.247
   last_sign_in_ip: 68.5.230.247
   created_at: 2012-11-10 23:53:33.147175000 Z
+  last_email_at: 2012-11-10 23:53:33.147175000 Z
   updated_at: 2012-11-10 23:53:33.203388000 Z
   zip:
   phone_number:


### PR DESCRIPTION
The same job should not increment `raw_emails_since_click` more than once.

This will prevent that (hopefully).