### PR TITLE
Poking inactive users based on favorite language(s)

### DIFF
--- a/app/jobs/background_inactive_email_job.rb
+++ b/app/jobs/background_inactive_email_job.rb
@@ -6,11 +6,13 @@ class BackgroundInactiveEmailJob < ApplicationJob
 
     with_most_issues = curated_repos_for(user).order_by_issue_count.first
     in_need = curated_repos_for(user).order_by_need.not_in(with_most_issues.id).first
+    random = curated_repos_for(user).rand.not_in(with_most_issues.id, in_need.id).first
+
     UserMailer.poke_inactive(
       user: user,
       most_issues_repo: with_most_issues,
       repo_in_need: in_need,
-      random_repo: curated_repos_for(user).rand.not_in(with_most_issues.id, in_need.id).first
+      random_repo: random
     ).deliver_later
   end
 

--- a/app/jobs/background_inactive_email_job.rb
+++ b/app/jobs/background_inactive_email_job.rb
@@ -3,6 +3,14 @@
 class BackgroundInactiveEmailJob < ApplicationJob
   def perform(user)
     return false if user.repo_subscriptions.present?
-    UserMailer.poke_inactive(user: user).deliver_later
+
+    most_issues_repo = Repo.order_by_issue_count.first
+    repo_in_need = Repo.order_by_need.not_in(most_issues_repo.id).first
+    UserMailer.poke_inactive(
+      user: user,
+      most_issues_repo: most_issues_repo,
+      repo_in_need: repo_in_need,
+      random_repo: Repo.rand.not_in(most_issues_repo.id, repo_in_need.id).first
+    ).deliver_later
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -71,11 +71,11 @@ class UserMailer < ActionMailer::Base
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "[CodeTriage] Help triage #{@repo.full_name}")
   end
 
-  def poke_inactive(user:)
+  def poke_inactive(user:, most_issues_repo:, repo_in_need:, random_repo:)
     return unless set_and_check_user(user)
-    @most_repo   = Repo.order_by_issue_count.first
-    @need_repo   = Repo.order_by_need.not_in(@most_repo.id).first
-    @random_repo = Repo.rand.not_in(@most_repo.id, @need_repo.id).first || @most_repo || @need_repo
+    @most_repo   = most_issues_repo
+    @need_repo   = repo_in_need
+    @random_repo = random_repo
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "CodeTriage misses you")
   end
 

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -174,7 +174,7 @@ class Repo < ActiveRecord::Base
 
   def self.in_user_lang_preferences(user)
     return all unless user.has_favorite_languages?
-    self.where('language IN (?)', user.favorite_languages)
+    self.where(language: user.favorite_languages)
   end
 
   def github_url

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -172,6 +172,11 @@ class Repo < ActiveRecord::Base
     self.where.not(id: user_subscribed_repo_ids)
   end
 
+  def self.in_user_lang_preferences(user)
+    return all unless user.has_favorite_languages?
+    self.where('language IN (?)', user.favorite_languages)
+  end
+
   def github_url
     File.join('https://github.com', full_name)
   end

--- a/app/views/user_mailer/poke_inactive.html.erb
+++ b/app/views/user_mailer/poke_inactive.html.erb
@@ -12,7 +12,7 @@ Help a repo in need:
 Help a random repo:
 <h3><%= link_to @random_repo.full_name, repo_url(@random_repo) %></h3><br />
 
-If you don't like any of those <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , root_url %> repos, or you can even subscribe to <%= link_to "CodeTriage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.<br /><br />
+If yoy don't like any of these options, remember that they are selected based in your language preferences (<%= link_to 'click here to change them', user_url(@user) %>). Not what you're looking for? <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , root_url %> repos, or you can even subscribe to <%= link_to "CodeTriage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.<br /><br />
 
 To unsubscribe entirely <%= link_to "delete your account", user_url(@user) %> but don't do that, subscribe to an issue above and do some good in the world. I believe in you.<br /><br />
 

--- a/app/views/user_mailer/poke_inactive.html.erb
+++ b/app/views/user_mailer/poke_inactive.html.erb
@@ -3,16 +3,22 @@ Hello <%= @user.github %>,<br /><br />
 
 You signed up to make a difference by triaging issues in github, which is great, but you didn't actually subscribe to any projects. To fix this just click on a link below, sign in, then click on the giant "subscribe" button:<br /><br />
 
-Help the repo with the most issues:
-<h3><%= link_to @most_repo.full_name, repo_url(@most_repo) %></h3><br />
+<% if @most_repo.present? %>
+  Help the repo with the most issues:
+  <h3><%= link_to @most_repo.full_name, repo_url(@most_repo) %></h3><br />
+<% end %>
 
-Help a repo in need:
-<h3><%= link_to @need_repo.full_name , repo_url(@need_repo) %></h3><br />
+<% if @need_repo.present? %>
+  Help a repo in need:
+  <h3><%= link_to @need_repo.full_name , repo_url(@need_repo) %></h3><br />
+<% end %>
 
-Help a random repo:
-<h3><%= link_to @random_repo.full_name, repo_url(@random_repo) %></h3><br />
+<% if @random_repo.present? %>
+  Help a random repo:
+  <h3><%= link_to @random_repo.full_name, repo_url(@random_repo) %></h3><br />
+<% end %>
 
-If yoy don't like any of these options, remember that they are selected based in your language preferences (<%= link_to 'click here to change them', user_url(@user) %>). Not what you're looking for? <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , root_url %> repos, or you can even subscribe to <%= link_to "CodeTriage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.<br /><br />
+If you don't like any of these options, remember that they are selected based on your language preferences (<%= link_to 'click here to change them', user_url(@user) %>). Not what you're looking for? <%= link_to "add your own", new_repo_url %> repo, <%= link_to "browse existing " , root_url %> repos, or you can even subscribe to <%= link_to "CodeTriage itself", File.join(root_url, "/codetriage/codetriage") %>. The important part is that you pick something to triage, or you will get this same email next week, maybe with different repos.<br /><br />
 
 To unsubscribe entirely <%= link_to "delete your account", user_url(@user) %> but don't do that, subscribe to an issue above and do some good in the world. I believe in you.<br /><br />
 

--- a/app/views/user_mailer/poke_inactive.text.erb
+++ b/app/views/user_mailer/poke_inactive.text.erb
@@ -13,11 +13,11 @@ Help a repo in need:
 Help a random repo:
 <%= @random_repo.full_name %> (<%= repo_url(@random_repo) %>)
 
-If you don't like any of those add your own repo (<%= new_repo_url %>), browse
-existing repos (<%= root_url %>), or you can even subscribe to code triage
-itself (<%=  File.join(root_url, "/codetriage/codetriage") %>).
-The important part is that you pick something to triage, or you will get this
-same email next week, maybe with different repos.
+If you don't like any of these options, remember that they're selected based on your language preferences
+(click here to change them: <%= user_url(@user) %>).
+Not what you're looking for? Browse existing repos (<%= root_url %>), or you can even subscribe to code triage itself
+(<%=  File.join(root_url, "/codetriage/codetriage") %>). The important part is that you pick something to triage,
+or you will get this same email next week, maybe with different repos.
 
 To unsubscribe entirely delete your account (<%= user_url(@user) %>) but don't
 do that, subscribe to an issue above and do some good in the world. I believe

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -15,7 +15,13 @@ class UserMailerTest < ActionMailer::TestCase
 
   test "poke_inactive works" do
     user = users(:schneems)
-    email = UserMailer.poke_inactive(user: user)
+    a_repo = repos(:rails_rails)
+    email = UserMailer.poke_inactive(
+      user: user,
+      most_issues_repo: a_repo,
+      repo_in_need: a_repo,
+      random_repo: a_repo
+    )
 
     assert_emails 1 do
       email.deliver_now

--- a/test/jobs/background_inactive_email_job_test.rb
+++ b/test/jobs/background_inactive_email_job_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class BackgroundInactiveEmailJobTest < ActiveJob::TestCase
-  test 'That we do not poke the user when he is subscribed to a repo' do
+  test 'That we do not poke the user when he/she is subscribed to a repo' do
     user_with_subscriptions = repo_subscriptions(:schneems_to_triage).user
 
     user_poked = BackgroundInactiveEmailJob.perform_now(user_with_subscriptions)
@@ -11,7 +11,7 @@ class BackgroundInactiveEmailJobTest < ActiveJob::TestCase
     assert_not user_poked
   end
 
-  test 'We poke the user when he is not subscribed to a repo' do
+  test 'We poke the user when he/she is not subscribed to a repo' do
     user_without_subscriptions = users(:empty)
 
     assert_enqueued_with(job: ActionMailer::DeliveryJob, queue: 'mailers') do

--- a/test/jobs/background_inactive_email_job_test.rb
+++ b/test/jobs/background_inactive_email_job_test.rb
@@ -3,7 +3,19 @@
 require 'test_helper'
 
 class BackgroundInactiveEmailJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'That we do not poke the user when he is subscribed to a repo' do
+    user_with_subscriptions = repo_subscriptions(:schneems_to_triage).user
+
+    user_poked = BackgroundInactiveEmailJob.perform_now(user_with_subscriptions)
+
+    assert_not user_poked
+  end
+
+  test 'We poke the user when he is not subscribed to a repo' do
+    user_without_subscriptions = users(:empty)
+
+    assert_enqueued_with(job: ActionMailer::DeliveryJob, queue: 'mailers') do
+      BackgroundInactiveEmailJob.perform_now(user_without_subscriptions)
+    end
+  end
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -129,16 +129,6 @@ class RepoTest < ActiveSupport::TestCase
     assert repos.include?(unsubscribed_repo)
   end
 
-  # test '.order_by_issue_count' do
-  #  expected_order_by_issues = [repos(:issue_triage_sandbox), repos(:rails_rails)]
-
-    # repos = Repo.order_by_issue_count
-
-    # assert_equal repos, expected_order_by_issues
-  # end
-
-  # Testing .in_user_lang_preferences
-
   test 'Returns matching repo according to user preferences' do
     javascript_repo = repos(:node)
     user = users(:schneems)

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -136,4 +136,36 @@ class RepoTest < ActiveSupport::TestCase
 
     # assert_equal repos, expected_order_by_issues
   # end
+
+  # Testing .in_user_lang_preferences
+
+  test 'Returns matching repo according to user preferences' do
+    javascript_repo = repos(:node)
+    user = users(:schneems)
+    user.favorite_languages = ['javascript']
+
+    javascript_repos = Repo.in_user_lang_preferences(user)
+
+    assert javascript_repos.include?(javascript_repo)
+  end
+
+  test 'Not returning a repo that is not included in the user preferences' do
+    javascript_repo = repos(:node)
+    user = users(:schneems)
+    user.favorite_languages = ['ruby']
+
+    ruby_repos = Repo.in_user_lang_preferences(user)
+
+    assert_not ruby_repos.include?(javascript_repo)
+  end
+
+  test 'Returns all the repos when the user has no language preferences' do
+    javascript_repo = repos(:node)
+    user = users(:schneems)
+    user.favorite_languages = []
+
+    all_repos = Repo.in_user_lang_preferences(user)
+
+    assert all_repos.include?(javascript_repo)
+  end
 end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -128,4 +128,12 @@ class RepoTest < ActiveSupport::TestCase
     assert_not repos.include?(subscribed_repo)
     assert repos.include?(unsubscribed_repo)
   end
+
+  # test '.order_by_issue_count' do
+  #  expected_order_by_issues = [repos(:issue_triage_sandbox), repos(:rails_rails)]
+
+    # repos = Repo.order_by_issue_count
+
+    # assert_equal repos, expected_order_by_issues
+  # end
 end


### PR DESCRIPTION
## Description

As a user, I want to receive repos where I can contribute to. 

## Related Issue
Closes #701

## Motivation and Context

When poking inactive users, we should consider their favorite languages so there're better chances of engagement.

## How Has This Been Tested?

- Missing tests poke inactive users job were added.
- Tested that repos were taking favorite language(s) into account with some unit tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

