### PR TITLE
Upgraded Ruby version in .travis.yml and Gemfile to 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only: [master]
 
 rvm:
-  - 2.5.0
+  - 2.5.1
 
 env:
   matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '>= 2.5', '< 2.7'
+ruby '2.5.1'
 
 git_source :github do |name|
   "https://github.com/#{name}.git"


### PR DESCRIPTION
Gemfile.lock specifies Ruby 2.5.1, but Travis still specifies 2.5.0.  This pull request resolves this discrepancy by bumping Ruby to 2.5.1 in the Travis environment.  Additionally, this pull request pins the Ruby version in the Gemfile at 2.5.1.  In other words, this pull request makes the Ruby version specification (2.5.1) consistent across the Gemfile, Gemfile.lock, and .travis.yml files.