### PR TITLE
Pinned Ruby version in Gemfile to 2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '>= 2.5', '< 2.7'
+ruby '2.5.1'
 
 git_source :github do |name|
   "https://github.com/#{name}.git"


### PR DESCRIPTION
This makes it consistent with the Ruby version specified in Gemfile.lock.