### PR TITLE
Upgraded Ruby to 2.5.1 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only: [master]
 
 rvm:
-  - 2.5.0
+  - 2.5.1
 
 env:
   matrix:


### PR DESCRIPTION
Gemfile.lock specifies Ruby 2.5.1.  This pull request makes the .travis.yml configuration consistent with that specified by Gemfile.lock.