### PR TITLE
Update get_process_mem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,3 +117,4 @@ gem 'premailer-rails'
 
 gem 'barnes'
 gem 'puma_worker_killer'
+gem 'get_process_mem', '0.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -729,7 +729,7 @@ GEM
     ffi (1.9.25)
     foreman (0.85.0)
       thor (~> 0.19.1)
-    get_process_mem (0.2.2)
+    get_process_mem (0.2.3)
     git_hub_bub (0.0.6)
       excon
       rrrretry
@@ -768,7 +768,7 @@ GEM
       kramdown
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    memory_profiler (0.9.11)
+    memory_profiler (0.9.12)
     metaclass (0.0.4)
     method_source (0.9.2)
     mime-types (3.2.2)
@@ -891,8 +891,7 @@ GEM
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     regexp_parser (1.3.0)
-    render_async (2.0.0)
-      bundler (~> 1.8)
+    render_async (2.0.2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -1018,6 +1017,7 @@ DEPENDENCIES
   dotenv-rails
   faker
   foreman
+  get_process_mem (= 0.2.3)
   git_hub_bub
   jquery-rails
   launchy


### PR DESCRIPTION
With the latest Ruby 2.6.0 update there is no more BigDecimal#new
method. We add explicit dependency on updated 'get_process_mem' gem that
has corresponding patch.