### PR TITLE
Display a single save button for docs triage

### DIFF
--- a/app/assets/stylesheets/components/_repo.scss
+++ b/app/assets/stylesheets/components/_repo.scss
@@ -56,6 +56,11 @@
     display: inline-block;
   }
 
+  .read {
+    float: left;
+    margin-right: 20px;
+  }
+
   .save-amount {
     background: none;
     color: $action-color;

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -54,12 +54,13 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           .repo-instructions
             = form_for(@repo_sub, html: {class: 'email-amount'}) do |f|
               label Triage more docs! (Or less)
-              = f.label "Read Docs"
-              = f.select :read_limit, (0..20)
-              = f.submit "Save", class: 'save-amount'
-              = f.label "Write Docs"
-              => f.select :write_limit, (0..20)
-              = f.submit "Save", class: 'save-amount'
+              .read
+                = f.label "Read Docs"
+                = f.select :read_limit, (0..20)
+              .write
+                = f.label "Write Docs"
+                => f.select :write_limit, (0..20)
+                = f.submit "Save", class: 'save-amount'
 
       - if user_signed_in? && current_user.able_to_edit_repo?(@repo)
         section.content-section


### PR DESCRIPTION
Current UX for triage settings is confusing. Even though both buttons work
in the same way a new user may think that he has to change read/write
settings one by one. This PR leaves a single button and slightly changes
the arrangement of items on the page.

**Old arrangement:**

![image](https://user-images.githubusercontent.com/525961/50724261-a2762c00-10fb-11e9-952c-43aa86c5303a.png)

**A new arrangement of elements look in this way:**

![image](https://user-images.githubusercontent.com/525961/50724211-df8dee80-10fa-11e9-980a-8dbe15b365fa.png)
