### PR TITLE
Added tests for issues and doc links

### DIFF
--- a/test/integration/maintaining_repo_subscriptions_test.rb
+++ b/test/integration/maintaining_repo_subscriptions_test.rb
@@ -34,6 +34,17 @@ class MaintainingRepoSubscriptionsTest < ActionDispatch::IntegrationTest
     assert page.has_content?("mockstar")
   end
 
+  test "clicking an issue leads to a github page" do
+    triage_the_sandbox
+    assert page.has_link?("first test issue", href: /github.com/)
+  end
+
+  test "clicking a doc leads to doc_methods" do
+    triage_the_sandbox
+    click_link "/path/here/issue_triage"
+    assert page.has_current_path?(/doc_methods/)
+  end
+
   # test "list only favorite languages" do
   #   login_via_github
   #   visit "/"


### PR DESCRIPTION
Simple tests created to analyze the basics functionalities that these links have to provide. The issue test checks if it contains a link and if the link leads to a github page. The doc test checks if the link will lead to the doc_methods page.