### PR TITLE
fix click_source_redirect method on doc_methods_controller

### DIFF
--- a/app/controllers/doc_methods_controller.rb
+++ b/app/controllers/doc_methods_controller.rb
@@ -33,10 +33,10 @@ class DocMethodsController < ApplicationController
 
   def click_source_redirect
     doc        = DocMethod.find(params[:id])
-    sub        = RepoSubscription.find_by!(id: params[:user_id], repo: doc.repo)
+    sub        = RepoSubscription.find_by!(user_id: params[:user_id], repo: doc.repo)
     assignment = DocAssignment.find_by!(doc_method_id: doc.id, repo_subscription_id: sub.id)
 
-    if assignment.user.id.to_s == params[:user_id]
+    if assignment&.user&.id.to_s == params[:user_id]
       assignment.user.record_click!
       assignment.update_attributes(clicked: true)
       assignment.user.update_attributes(last_clicked_at: Time.now)


### PR DESCRIPTION
While making tests for the class (#943), I've noticed that this method wasn't working properly because of two errors:

 - on line 36 the search for a `RepoSubscription` was not being made correctly, which would consequently lead to the `sub` variable being nil.
- on line 39 the `if` conditional was raising an error in case the condition wasn't met instead of just executing the `else` instruction. To fix it I've prevented the condition of raising an error.