### PR TITLE
add 'jump to issue' button

### DIFF
--- a/app/controllers/issue_assignments_controller.rb
+++ b/app/controllers/issue_assignments_controller.rb
@@ -17,4 +17,16 @@ class IssueAssignmentsController < ApplicationController
       redirect_to :root, message: "Bad url, if this problem persists please open an issue github.com/codetriage/codetriage"
     end
   end
+
+  def jump_to_issue
+    if IssueAssignment.where(repo_subscription_id: params[:repo_sub_id]).any?
+      issue_assignment = IssueAssignment.where(repo_subscription_id: params[:repo_sub_id]).sample
+      issue_assignment.user.record_click!
+      issue_assignment.update_attributes(clicked: true)
+      issue_assignment.user.update_attributes(last_clicked_at: Time.now)
+      redirect_to issue_assignment.issue.html_url
+    else
+      redirect :root, message: "Something went wrong"
+    end
+  end
 end

--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -39,6 +39,13 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           = link_to issue_assignments_path(id: @repo_sub.id), class: 'button repo-action', method: :post do
             | Send me a new issue!
 
+    -if @repo_sub&.issues&.any?
+      section.help-triage.content-section
+        h2.content-section-title Jump to an Issue!
+        .repo-instructions If you prefer you can go straight into an issue from the project's repository.
+        = link_to jump_to_issue_path(repo_sub_id: @repo_sub.id), class: 'button repo-action', method: :get do
+          | Send me straight to an issue!
+
     section.help-triage.content-section
       - if @repo_sub.blank? || (@repo_sub.write.blank? && @repo_sub.read.blank?)
         h2.content-section-title Triage Docs!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ CodeTriage::Application.routes.draw do
   resources   :issue_assignments, only: [:create]
 
   get "/issue_assignments/:id/users/:user_id/click",  to: "issue_assignments#click_issue_redirect", as: :issue_click
+  get "/issue_assignments/users/:repo_sub_id/issue",  to: "issue_assignments#jump_to_issue",        as: :jump_to_issue
   get "/doc_methods/:id/users/:user_id/click",        to: "doc_methods#click_method_redirect",      as: :doc_method_click
   get "/doc_methods/:id/users/:user_id/source_click", to: "doc_methods#click_source_redirect",      as: :doc_source_click
 

--- a/test/functional/issue_assignments_controller_test.rb
+++ b/test/functional/issue_assignments_controller_test.rb
@@ -31,4 +31,13 @@ class IssueAssignmentsControllerTest < ActionController::TestCase
 
     assert_redirected_to :root
   end
+
+  test '#jump_to_issue sends the user to the issue url when clicked' do
+    repo = repo_subscriptions(:schneems_to_triage)
+    issue_assignments = issue_assignments(:one)
+
+    get :jump_to_issue, params: { repo_sub_id: repo.id }
+
+    assert_redirected_to issue_assignments.issue.html_url
+  end
 end


### PR DESCRIPTION
Related to #789 

This is how the button looks, it only appears when the repository has issues.
![image](https://user-images.githubusercontent.com/33486409/55978665-ad92a800-5c66-11e9-9e40-f84372d30e68.png)

Although the feature is ready and tested, I do think it could have some improvements on the selection of issues, so it doesn't just randomly selects one. Also on the [feature request page](#789), it's mentioned the addition of a rate limit, which I think it's a good idea, but I'm not quite sure the best place of adding this feature.

I'm open to any suggestions and I'll try to make the changes as soon as I can. Thanks!