### PR TITLE
Issues per day

### DIFF
--- a/app/assets/stylesheets/components/_repo-list.scss
+++ b/app/assets/stylesheets/components/_repo-list.scss
@@ -122,3 +122,8 @@
   @include position(absolute, null null $base-spacing null);
   color: $lightest-font-color;
 }
+
+.repo-item-issues-per-day {
+  color: $lightest-font-color;
+  font-size: 12px;
+}

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -17,7 +17,7 @@ class Repo < ActiveRecord::Base
             1
         END)::integer) as amount")
         .joins(:repo)
-        .group('repos.created_at')
+        .group('repos.created_at')[0]
     end
   end
   has_many :repo_subscriptions

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -7,7 +7,19 @@ class Repo < ActiveRecord::Base
   validates :name, :user_name, presence: true
   validate :github_url_exists, on: :create
 
-  has_many :issues
+  has_many :issues do
+    def per_day
+      select("(COUNT(issues.id) /
+        (CASE
+          WHEN DATE_PART('day', now() - repos.created_at) <> 0
+            THEN DATE_PART('day', now() - repos.created_at)
+          ELSE
+            1
+        END)::integer) as amount")
+        .joins(:repo)
+        .group('repos.created_at')
+    end
+  end
   has_many :repo_subscriptions
   has_many :users, through: :repo_subscriptions
   has_many :subscribers, through: :repo_subscriptions, source: :user

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -18,7 +18,7 @@ class Repo < ActiveRecord::Base
             1
         END)::integer) as amount")
         .joins(:repo)
-        .group('repos.created_at')[0] || JSON.parse({:amount => 0}.to_json, object_class: OpenStruct)
+        .group('repos.created_at')[0] || JSON.parse({ :amount => 0 }.to_json, object_class: OpenStruct)
     end
   end
   has_many :repo_subscriptions

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -10,7 +10,7 @@ class Repo < ActiveRecord::Base
 
   has_many :issues, dependent: :destroy do
     def per_day
-      amount = select("(COUNT(issues.id) /
+      select("(COUNT(issues.id) /
         (CASE
           WHEN DATE_PART('day', now() - repos.created_at) <> 0
             THEN DATE_PART('day', now() - repos.created_at)

--- a/app/views/repos/_repo.html.slim
+++ b/app/views/repos/_repo.html.slim
@@ -12,3 +12,5 @@ li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.la
     - if repo.full_name.present?
       span.repo-item-full-name
         | (#{repo.full_name})
+    span.repo-item-issues-per-day
+      | #{repo.issues.per_day[0].amount} Issue/Day

--- a/app/views/repos/_repo.html.slim
+++ b/app/views/repos/_repo.html.slim
@@ -13,4 +13,4 @@ li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.la
       span.repo-item-full-name
         | (#{repo.full_name})
     span.repo-item-issues-per-day
-      | #{repo.issues.per_day[0].amount} Issue/Day
+      | #{repo.issues.per_day.nil? ? 0 : repo.issues.per_day.amount} Issue/Day

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -120,9 +120,9 @@ class RepoTest < ActiveSupport::TestCase
   end
 
   test 'issues.per_day' do
-    repo = Repo.create user_name: 'edumoreira1506', name: 'tic-tac-toe'
+    repo = Repo.create(user_name: 'edumoreira1506', name: 'tic-tac-toe')
     10.times { Issue.create repo_id: repo.id, state: 'open' }
-    assert_equal 10, repo.issues.per_day.amount
+    assert_equal repo.issues.length, repo.issues.per_day.amount
   end
 
   test '.without_user_subscriptions' do

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -120,8 +120,8 @@ class RepoTest < ActiveSupport::TestCase
   end
 
   test 'issues.per_day' do
-    repo = Repo.create(name: 'tic-tac-toe', user_name: 'edumoreira1506')
-    10.times { Issue.create(repo_id: repo.id, state: 'open') }
+    repo = Repo.create user_name: 'edumoreira1506', name: 'tic-tac-toe'
+    10.times { Issue.create repo_id: repo.id, state: 'open' }
     assert_equal 10, repo.issues.per_day.amount
   end
 

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -120,9 +120,9 @@ class RepoTest < ActiveSupport::TestCase
   end
 
   test 'issues.per_day' do
-    repo = Repo.create(name: 'codetriage', user_name: 'codetriage')
-    10.times { Issue.create(repo: repo, state: 'open') }
-    assert_equal 10, repo.issues.per_day
+    repo = Repo.create(name: 'tic-tac-toe', user_name: 'edumoreira1506')
+    10.times { Issue.create(repo_id: repo.id, state: 'open') }
+    assert_equal 10, repo.issues.per_day.amount
   end
 
   test '.without_user_subscriptions' do

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -119,6 +119,12 @@ class RepoTest < ActiveSupport::TestCase
     end
   end
 
+  test 'issues.per_day' do
+    repo = Repo.create(name: 'codetriage', user_name: 'codetriage')
+    10.times { Issue.create(repo: repo, state: 'open') }
+    assert_equal 10, repo.issues.per_day
+  end
+
   test '.without_user_subscriptions' do
     user = users(:schneems)
     subscribed_repo = user.repo_subscriptions.first


### PR DESCRIPTION
## Description
Hello guys! I saw the issue #705 and I think than know how much issues have per day in a repository would be very nice, so I added this feature. :)
Basically I had take the field Repo.created_at, than is the date of when the repo was inserted in codetriage and made the difference in days to now. Like, the repo was created at: '2019-01-01' and today is '2019-11-01', so has 10 days of difference, ok this is the first step, and after we need of the amount of issues of that repository. Like the repository have 10 issues the calc is: 10 issues / 10 repositorys give to us 1 issue per day!

In the next example. we have just one repository, this repository have 69 issues, but was opened today, so is 69 issues / 1 day:
![Screenshot from 2019-09-17 14-20-11](https://user-images.githubusercontent.com/49662698/65064294-84cdb780-d956-11e9-9d96-a00b4c5b8c99.png)

