### PR TITLE
Amount code helpers

### DIFF
--- a/app/assets/stylesheets/components/_repo-list.scss
+++ b/app/assets/stylesheets/components/_repo-list.scss
@@ -122,3 +122,8 @@
   @include position(absolute, null null $base-spacing null);
   color: $lightest-font-color;
 }
+
+.repo-item-code-helpers {
+  color: $lightest-font-color;
+  font-size: 12px;
+}

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'docs_doctor/parsers/ruby/yard'
-require 'open-uri'
+require 'net/http'
 require 'json'
 
 class Repo < ActiveRecord::Base
@@ -111,8 +111,8 @@ class Repo < ActiveRecord::Base
   end
 
   def amount_code_helpers
-    apiResponse = open("https://api.github.com/repos/#{full_name}/contributors").read
-    JSON.parse(apiResponse).length
+    apiResponse = Net::HTTP.get_response(URI.parse("https://api.github.com/repos/#{full_name}/contributors"))
+    apiResponse.code == '200' ? JSON.parse(apiResponse.body).length : 0    
   end
 
   def subscriber_count

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -111,7 +111,7 @@ class Repo < ActiveRecord::Base
   end
 
   def amount_code_helpers
-    apiResponse = open("https://api.github.com/repos/#{user_name}/#{name}/contributors").read
+    apiResponse = open("https://api.github.com/repos/#{full_name}/contributors").read
     JSON.parse(apiResponse).length
   end
 

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'docs_doctor/parsers/ruby/yard'
+require 'open-uri'
+require 'json'
 
 class Repo < ActiveRecord::Base
   # Now done at the DB level # validates :name, uniqueness: {scope: :user_name, case_sensitive: false }
@@ -106,6 +108,11 @@ class Repo < ActiveRecord::Base
     else
       "".freeze
     end
+  end
+
+  def amount_code_helpers
+    apiResponse = open("https://api.github.com/repos/#{user_name}/#{name}/contributors").read
+    JSON.parse(apiResponse).length
   end
 
   def subscriber_count

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -112,7 +112,7 @@ class Repo < ActiveRecord::Base
 
   def amount_code_helpers
     apiResponse = Net::HTTP.get_response(URI.parse("https://api.github.com/repos/#{full_name}/contributors"))
-    apiResponse.code == '200' ? JSON.parse(apiResponse.body).length : 0    
+    apiResponse.code == '200' ? JSON.parse(apiResponse.body).length : 0
   end
 
   def subscriber_count

--- a/app/views/repos/_repo.html.slim
+++ b/app/views/repos/_repo.html.slim
@@ -12,3 +12,6 @@ li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.la
     - if repo.full_name.present?
       span.repo-item-full-name
         | (#{repo.full_name})
+
+    span.repo-item-code-helpers
+      | #{repo.amount_code_helpers} code helpers

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -81,7 +81,6 @@ class RepoTest < ActiveSupport::TestCase
   test "amount_code_helpers should return amount of contributors" do
     apiResponse = open("https://api.github.com/repos/rails/sprockets/contributors").read
     amountContributors = JSON.parse(apiResponse).length
-    
     repository = Repo.new(user_name: 'rails', name: 'sprockets', full_name: 'rails/sprockets')
     assert_equal repository.amount_code_helpers, amountContributors
   end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -78,6 +78,14 @@ class RepoTest < ActiveSupport::TestCase
     assert_not Repo.exists_with_name?("prathamesh-sonpatki/issue_triage_sandbox")
   end
 
+  test "amount_code_helpers should return amount of contributors" do
+    apiResponse = open("https://api.github.com/repos/rails/sprockets/contributors").read
+    amountContributors = JSON.parse(apiResponse).length
+    
+    repository = Repo.new(user_name: 'rails', name: 'sprockets', full_name: 'rails/sprockets')
+    assert_equal repository.amount_code_helpers, amountContributors
+  end
+
   test "issues_fetcher.api_path (private method) returns issues path with Github api" do
     repo = Repo.new(name: 'codetriage', user_name: 'codetriage')
     assert_equal "repos/codetriage/codetriage/issues", repo.issues_fetcher.send(:api_path)


### PR DESCRIPTION
## Description

Hello guys! I saw the issue #954 that said about the amount of code helpers in a repository, so I think than add a new field on database should be complicated because have a lot of data and would be very heavy to update all of them.
So my solution is to use the GitHub API, in API we can get all contributors of each single repository, and the contributors are exactly the code helpers of the issue said about. 
Maybe we can change to other form, but i hope that helps :)

Image example:
![Screenshot from 2019-09-18 10-10-19](https://user-images.githubusercontent.com/49662698/65151482-96699a80-d9fc-11e9-89e9-0b62bf962b1e.png)
