### PR TITLE
Fixed url input color not readable

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -36,6 +36,7 @@ select{
   padding: $small-spacing;
   transition: border-color $base-duration $base-timing;
   width: 100%;
+  color: inherit;
 
   &:hover {
     border-color: shade($base-border-color, 20%);
@@ -56,6 +57,22 @@ select{
     }
   }
 
+  ::-webkit-input-placeholder {
+    color: rgba($white, 0.3);
+  }
+
+  ::-moz-placeholder {
+    color: rgba($white, 0.3);
+  }
+
+  :-ms-input-placeholder {
+    color: rgba($white, 0.3);
+  }
+
+  ::-ms-input-placeholder {
+    color: rgba($white, 0.3);
+  }
+
   ::placeholder {
     color: rgba($white, 0.3);
   }
@@ -66,7 +83,9 @@ textarea {
 }
 
 input[type="search"] {
-  appearance: none;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
 }
 
 input[type="checkbox"],


### PR DESCRIPTION
## Description
In _**./app/assets/stylesheets/base/_forms.scss**_ added:
```scss
#{$all-text-inputs},
select{
  ...
  color: inherit;
}
```

## Related Issue
[#1097](https://github.com/codetriage/codetriage/issues/1097)

## Motivation and Context
This minor change improved readability thus avoiding typos in repo url inputs.

## Screenshots
|Bug | Fixed|
| :-: | :-: |
|![codetriangle-bug](https://user-images.githubusercontent.com/49572628/65978833-61b90280-e442-11e9-9b25-8772200ee553.png) | ![codetriangle-fix](https://user-images.githubusercontent.com/49572628/65978838-6382c600-e442-11e9-9d1e-349fa22f37e7.png)|

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
