### PR TITLE
Make query much smaller

### DIFF
--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class SendDailyTriageEmailJob < ApplicationJob
-  def perform(user)
-    return false if skip?(user)
+  def perform(user, force_send: false)
+    return false if !force_send && skip?(user)
 
     send_daily_triage!(user)
   end

--- a/app/models/doc_mailer_maker.rb
+++ b/app/models/doc_mailer_maker.rb
@@ -76,7 +76,11 @@ class DocMailerMaker
 
   # Sends email to +user+ containing current batch of +read_docs+ and +write_docs+.
   def mail
-    UserMailer.daily_docs(user: user, write_docs: write_docs, read_docs: read_docs)
+    UserMailer.daily_docs(
+      user: user,
+      write_docs: write_docs,
+      read_docs: read_docs
+    )
   end
 
   # Triggers mail delivery unless there are no +read_docs+ or +write_docs+ to mail


### PR DESCRIPTION
With this code the query becomes:

```
SELECT "doc_methods".* FROM "doc_methods"
WHERE "doc_methods"."repo_id" = $1
  AND (doc_comments_count > 0)
  AND "doc_methods"."active" = $2
  AND (doc_methods.id NOT IN (
      SELECT "doc_assignments"."doc_method_id" FROM "doc_assignments" WHERE "doc_assignments"."repo_subscription_id" = 84189)
    )
  AND "doc_methods"."skip_read" = $3
  ORDER BY RANDOM()
  LIMIT $4
```

Previously it would grow unbounded since we were manually mapping and passing in IDs:

https://gist.github.com/schneems/b568ad370c6b90ab236ebd455f4a20a5


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.