### PR TITLE
Test DOC parsing and move to run in a fork

### DIFF
--- a/app/models/github_fetcher/repo.rb
+++ b/app/models/github_fetcher/repo.rb
@@ -18,7 +18,8 @@ module GithubFetcher
     # TODO - does this really belong here? Seems like it (and Repo#populate_docs!)
     #   should move into the PopulateDocs job
     def clone
-      `cd #{dir} && git clone #{clone_url} 2>&1`
+      out = `cd #{dir} && git clone #{clone_url} 2>&1`
+      raise "Error executing git clone #{clone_url.inspect}: #{out.inspect}" unless $?.success?
       return dir
     end
 

--- a/test/fixtures/repos.yml
+++ b/test/fixtures/repos.yml
@@ -1,3 +1,13 @@
+get_process_mem:
+  user_name: schneems
+  name: get_process_mem
+  full_name: schneems/get_process_mem
+  language: ruby
+  created_at: 2012-11-10 21:50:48.351554000 Z
+  updated_at: 2012-11-10 21:50:48.351554000 Z
+  issues_count: 1
+  commit_sha: 254d1a25cdc949ff7ef41f038a419eb2576bcef0
+
 issue_triage_sandbox:
   user_name: bemurphy
   name: issue_triage_sandbox

--- a/test/jobs/parse_docs_test.rb
+++ b/test/jobs/parse_docs_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParseDocsTest < ActiveJob::TestCase
+  test "Can parse yard docs in a fork" do
+    repo = repos(:get_process_mem)
+    assert_equal 0, repo.doc_methods.count
+
+    parser = DocsDoctor::Parsers::Ruby::Yard.new(
+      get_process_mem_disk_location
+    )
+    parser.in_fork do
+      parser.process
+      parser.store(repo)
+
+      refute_equal 0, repo.doc_methods.count
+
+      assert DocMethod.where(repo_id: repo).where(path: "GetProcessMem#initialize").any?
+    end
+  end
+
+  test "Does not error" do
+    repos(:get_process_mem)
+      .populate_docs!(
+        location: get_process_mem_disk_location,
+        commit_sha: repos(:get_process_mem).commit_sha
+      )
+  end
+
+  test "Errors are caught in fork" do
+    assert_raise do
+      DocsDoctor::Parsers::Ruby::Yard.new(
+        get_process_mem_disk_location
+      ).in_fork { raise "foo" }
+    end
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,3 +78,15 @@ end
 require 'mocha/setup'
 require 'minitest/mock'
 require 'sidekiq/testing'
+
+
+def get_process_mem_disk_location
+  tmp_path = File.expand_path("../../tmp", __FILE__)
+  path = File.join(tmp_path, "get_process_mem")
+  return path if Dir.exist?(path)
+
+  out = `cd #{tmp_path} && git clone https://github.com/schneems/get_process_mem`
+  raise "Cloning failed #{out.inspect}" unless $?.success?
+
+  return path
+end

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -108,10 +108,9 @@ class RepoTest < ActiveSupport::TestCase
     repo = repos(:rails_rails)
 
     VCR.use_cassette "repo_populate_docs" do
-      double = +'double'
+      double = Object.new
       DocsDoctor::Parsers::Ruby::Yard.stub(:new, ->(_) { double }) do
-        double.expects(:process)
-        double.expects(:store)
+        double.expects(:in_fork)
         assert_nil repo.commit_sha
         repo.populate_docs!
         assert_not_nil repo.commit_sha


### PR DESCRIPTION

Parsing DOCs is extremely expensive on memory and our workers are constantly swapping. The goal is to mitigate this a tad by doing all the known memory intensive work inside of a fork. After we're done the fork goes away and with it, all of it's memory.

If this doesn't help then the next step would be to patch YARD to allow for the ability to incrementally generate docs instead of generating all the docs and loading into memory up front.
