### PR TITLE
Move expensive SQL query out of loop

### DIFF
--- a/app/jobs/background_inactive_email_job.rb
+++ b/app/jobs/background_inactive_email_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class BackgroundInactiveEmailJob < ApplicationJob
-  def perform(user)
+  def perform(user, repos_by_need_ids: repos_by_need_ids)
     return false if user.repo_subscriptions.present?
-    UserMailer.poke_inactive(user: user).deliver_later
+    UserMailer.poke_inactive(user: user, repos_by_need_ids: repos_by_need_ids).deliver_later
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -71,10 +71,13 @@ class UserMailer < ActionMailer::Base
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "[CodeTriage] Help triage #{@repo.full_name}")
   end
 
-  def poke_inactive(user:)
+  def poke_inactive(user:, repos_by_need_ids:)
     return unless set_and_check_user(user)
-    @most_repo   = Repo.order_by_issue_count.first
-    @need_repo   = Repo.order_by_need.not_in(@most_repo.id).first
+    @most_repo = Repo.order_by_issue_count.first
+
+    repo_need_id = repos_by_need_ids.detect { |id| id != @most_repo.id }
+    @need_repo = Repo.where(id: repo_need_id).first
+
     @random_repo = Repo.rand.not_in(@most_repo.id, @need_repo.id).first || @most_repo || @need_repo
     mail(to: @user.email, reply_to: "noreply@codetriage.com", subject: "CodeTriage misses you")
   end

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -30,8 +30,10 @@ namespace :schedule do
   desc 'Sends an email to invite users to engage once a week'
   task poke_inactive: :environment do
     next unless Date.today.tuesday?
+
+    repos_by_need_ids = Repo.order_by_need.first(10).map(&:id)
     User.inactive.find_each(batch_size: 100) do |user|
-      BackgroundInactiveEmailJob.perform_later(user)
+      BackgroundInactiveEmailJob.perform_later(user, repos_by_need_ids: repos_by_need_ids)
     end
   end
 

--- a/test/functional/user_mailer_test.rb
+++ b/test/functional/user_mailer_test.rb
@@ -15,7 +15,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   test "poke_inactive works" do
     user = users(:schneems)
-    email = UserMailer.poke_inactive(user: user)
+    email = UserMailer.poke_inactive(user: user, repos_by_need_ids: Repo.first(10).map(&:id))
 
     assert_emails 1 do
       email.deliver_now

--- a/test/jobs/parse_docs_test.rb
+++ b/test/jobs/parse_docs_test.rb
@@ -36,4 +36,3 @@ class ParseDocsTest < ActiveJob::TestCase
     end
   end
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,7 +79,6 @@ require 'mocha/setup'
 require 'minitest/mock'
 require 'sidekiq/testing'
 
-
 def get_process_mem_disk_location
   tmp_path = File.expand_path("../../tmp", __FILE__)
   path = File.join(tmp_path, "get_process_mem")


### PR DESCRIPTION
This SQL query currently accounts for 28% of IO time even though it's only called half as much as the next most frequent query

```
 00:19:21.386247 | 28.6%          | 19,761    | 00:00:00.068624 | SELECT  "repos".* FROM "repos" INNER JOIN "repo_subscriptions" ON "repo_subscriptions"."repo_id" = "repos"."id" WHERE (repos.id not in ($2)) GROUP BY repos.id ORDER BY issues_count::float/COUNT(repo_subscriptions.repo_id) DESC LIMIT $1
```

Instead of calling it for every user (since it's the same result set) we can call it once outside of the loop and pass it in.

