### PR TITLE
Fewer SQL queries when assigning issues

### DIFF
--- a/app/models/issue_assigner.rb
+++ b/app/models/issue_assigner.rb
@@ -54,7 +54,7 @@ class IssueAssigner
   private def issues_for_sub(sub)
     sql = <<~SQL
       SELECT
-        id
+        id, state, pr_attached
       FROM
         issues
       WHERE

--- a/app/models/issue_assigner.rb
+++ b/app/models/issue_assigner.rb
@@ -1,56 +1,78 @@
 # frozen_string_literal: true
 
 # PORO
+# This class takes in a user and their subscriptions and generates IssueAssignment's for
+# each of the subscriptions based on that subscription's `email_limit`
+#
+# Example:
+#
+#   user = User.first
+#   assigner = IssueAssigner.new(user, user.repo_subscriptions)
+#   assigner.assign!
+#
 class IssueAssigner
   attr_reader :user, :subscriptions
 
   def initialize(user, subscriptions)
     @user          = user
     @subscriptions = subscriptions
+    @assigned_count_hash = Hash.new { |hash, key| hash[key] = 0 }
   end
 
   def assign!
     subscriptions.each do |sub|
-      Array.new(sub.email_limit) do
-        assign_issue_for_sub(sub)
-      end
+      assign_issues_for_sub(sub)
     end
+
     self
   end
 
-  private
+  private def stop?(sub)
+    @assigned_count_hash[sub] >= sub.email_limit
+  end
 
-  def assign_issue_for_sub(sub)
-    issue = Issue.find_by_sql(<<-SQL
-                SELECT
-                  *
-                FROM
-                  issues
-                WHERE
-                  repo_id = '#{sub.repo_id}' and
-                  state   = '#{Issue::OPEN}'
-                  AND id NOT IN (
-                    SELECT
-                      issue_id
-                    FROM
-                      issue_assignments
-                    WHERE
-                      repo_subscription_id = '#{sub.id}'
-                  )
-                ORDER BY
-                  random()
-                LIMIT
-                  1
-                SQL
-                             ).first
+  private def assign_issues_for_sub(sub)
+    issues = issues_for_sub(sub)
 
-    return false if issue.blank?
-    if issue.valid_for_user?(user)
-      sub.issue_assignments.create(issue_id: issue.id)
-    else
-      # prevent selecting this issue again and try to find another one
-      sub.issue_assignments.create(issue_id: issue.id, delivered: true) &&
-        assign_issue_for_sub(sub) # yay recursion!
+    return if issues.empty?
+
+    issues.each do |issue|
+      next if stop?(sub)
+
+      if issue.valid_for_user?(user)
+        sub.issue_assignments.create(issue_id: issue.id)
+        @assigned_count_hash[sub] += 1
+      else
+        # prevent selecting this issue again and try to find another one
+        sub.issue_assignments.create(issue_id: issue.id, delivered: true)
+      end
     end
+
+    assign_issues_for_sub(sub) unless stop?(sub)
+  end
+
+  private def issues_for_sub(sub)
+    sql = <<~SQL
+      SELECT
+        *
+      FROM
+        issues
+      WHERE
+        repo_id = :repo_id and
+        state   = :issue_state
+        AND id NOT IN (
+          SELECT
+            issue_id
+          FROM
+            issue_assignments
+          WHERE
+            repo_subscription_id = :sub_id
+        )
+      ORDER BY
+        random()
+      LIMIT
+        :email_limit
+    SQL
+    Issue.find_by_sql([sql, { sub_id: sub.id, issue_state: Issue::OPEN, repo_id: sub.repo_id, email_limit: sub.email_limit }]).first(sub.email_limit)
   end
 end

--- a/app/models/issue_assigner.rb
+++ b/app/models/issue_assigner.rb
@@ -54,7 +54,7 @@ class IssueAssigner
   private def issues_for_sub(sub)
     sql = <<~SQL
       SELECT
-        *
+        id
       FROM
         issues
       WHERE

--- a/test/unit/issue_assignment_test.rb
+++ b/test/unit/issue_assignment_test.rb
@@ -8,4 +8,41 @@ class IssueAssignmentTest < ActiveSupport::TestCase
     ia.valid?
     assert_equal ["can't be blank"], ia.errors[:issue_id]
   end
+
+  test "issue assigner class works" do
+    user = users(:schneems)
+
+    # schneems has 2 repo subscriptions, only the first one has
+
+    user.issue_assignments.where(delivered: false).delete_all
+
+    assigner = IssueAssigner.new(user, user.repo_subscriptions)
+    assigner.assign!
+
+    assert_equal 3, user.issue_assignments.where(delivered: false).count
+  end
+
+  test "respects email limits" do
+    user = users(:schneems)
+
+    user.issue_assignments.where(delivered: false).delete_all
+
+    user.repo_subscriptions.each do |sub|
+      3.times do
+        sub.repo.issues.create!(state: Issue::OPEN)
+      end
+    end
+
+    subscriptions = user.repo_subscriptions.all
+    first_sub = subscriptions.first
+    second_sub = subscriptions.last
+    def first_sub.email_limit; 1; end
+
+    def second_sub.email_limit; 1; end
+
+    assigner = IssueAssigner.new(user, [first_sub, second_sub])
+    assigner.assign!
+
+    assert_equal 2, user.issue_assignments.where(delivered: false).count
+  end
 end


### PR DESCRIPTION
Right now we execute a SQL query for every repo subscribed to multiplied by the number of issues a person wants to receive for that repo.

With this PR we now try to find all of the issues with one query, this reduces the number of queries when sending out issues to the number of repos subscribed to rather than the number of repos subscribed to multiplied by the number of issues.