### PR TITLE
Fix Repo not being created for issues

### DIFF
--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -50,7 +50,7 @@ class PopulateIssuesJob < ApplicationJob
 
       # Create issues that didn't
       issue_number_to_github_hash.each_value do |issue_hash|
-        Issue.create_from_github_hash!(issue_hash)
+        Issue.create_from_github_hash!(issue_hash, repo: @repo)
       end
 
       !fetcher.last_page?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -85,10 +85,11 @@ class Issue < ActiveRecord::Base
                  pr_attached: pr_attached_with_issue?(issue_hash['pull_request']))
   end
 
-  def self.create_from_github_hash!(issue_hash)
+  def self.create_from_github_hash!(issue_hash, repo:)
     last_touched_at = issue_hash['updated_at'] ? DateTime.parse(issue_hash['updated_at']) : nil
 
-    Issue.create!(title: issue_hash['title'],
+    Issue.create!(repo_id: repo.id,
+                  title: issue_hash['title'],
                   url: issue_hash['url'],
                   last_touched_at: last_touched_at,
                   state: issue_hash['state'],

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -16,6 +16,3 @@ Rails.application.config.action_controller.forgery_protection_origin_check = tru
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 ActiveSupport.to_time_preserves_timezone = true
-
-# Require `belongs_to` associations by default. Next major version defaults to true.
-Rails.application.config.active_record.belongs_to_required_by_default = false

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -37,6 +37,7 @@ class IssueTest < ActiveSupport::TestCase
     issue = Issue.new
 
     issue.state = "open"
+    issue.repo = Repo.first
     assert issue.valid?
 
     issue.state = "closed"


### PR DESCRIPTION
Getting tons of errors in prod `ActiveRecord::RecordInvalid Validation failed: Repo must exist`

From


```
  def self.create_from_github_hash!(issue_hash)
    last_touched_at = issue_hash['updated_at'] ? DateTime.parse(issue_hash['updated_at']) : nil

    Issue.create!(title: issue_hash['title'], # < =======================
                  url: issue_hash['url'],
                  last_touched_at: last_touched_at,
                  state: issue_hash['state'],
``` 

But my tests pass locally. Lead me to ask this on twitter https://twitter.com/schneems/status/1184291882110726147 and found that the defaults changed and need to be updated in the project 
https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html
