### PR TITLE
Allow API Fetcher Retry on bad token

### DIFF
--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -21,6 +21,9 @@ class PopulateIssuesJob < ApplicationJob
   def populate_issues(page_number)
     fetcher = repo.issues_fetcher
     fetcher.page = page_number
+
+    fetcher.call(retry_on_bad_token: 3)
+
     if fetcher.error?
       repo.update(github_error_msg: fetcher.error_message)
       false

--- a/app/models/github_fetcher/resource.rb
+++ b/app/models/github_fetcher/resource.rb
@@ -10,6 +10,23 @@ module GithubFetcher
     #   other changes made to this base call in the future)
     def initialize(options)
       @options = options
+      reset!
+    end
+
+    def call(retry_on_bad_token: false)
+      resp = response
+
+      return resp unless bad_token?
+      return resp unless retry_on_bad_token
+
+      unless retry_on_bad_token.is_a?(Integer)
+        raise "retry_on_bad_token must be a number but is #{retry_on_bad_token.class}: #{retry_on_bad_token.inspect}"
+      end
+
+      return resp if retry_on_bad_token <= 0
+
+      reset!
+      call(retry_on_bad_token: retry_on_bad_token - 1)
     end
 
     # Generally not over-ridden
@@ -28,16 +45,23 @@ module GithubFetcher
                     end
     end
 
+    def bad_token?
+      if response.status == 401 && response.body.match?(/Bad credentials/)
+        @error = @error_message = "Bad credentials"
+        return true
+      end
+      false
+    end
+
     def error?
       # Ensure API request has been made (by calling `as_json` before returning
       #   error if it happened. `as_json` should always evaluate truthily, but
       #   @error will be false unless there's an error in the API request
-      as_json && @error
+      bad_token? || @error
     end
 
     def page=(number)
-      @response = nil
-      @as_json = nil
+      reset!
       options[:page] = number
       @page = number
     end
@@ -48,16 +72,23 @@ module GithubFetcher
 
     private
 
+    private def reset!
+      @response = nil
+      @as_json = nil
+      @error = nil
+      @error_message = nil
+    end
+
     attr_reader :api_path, :options
 
     # Sometimes over-ridden to use the error
-    def null_response(_error)
+    private def null_response(_error)
       GitHubBub::Response.new(body: null_response_body.to_json)
     end
 
     # Sometimes over-ridden to set a specific response when GitHubBub API call
     #   fails.
-    def null_response_body
+    private def null_response_body
       {}
     end
   end

--- a/test/jobs/populate_issues_job_test.rb
+++ b/test/jobs/populate_issues_job_test.rb
@@ -32,7 +32,9 @@ class PopulateIssuesJobTest < ActiveJob::TestCase
   test "#populate_multi_issues stores error info when fails" do
     repo = repos(:issue_triage_sandbox)
     def repo.issues_fetcher
-      OpenStruct.new(error?: true, error_message: 'something went wrong', page: 1)
+      fetcher = OpenStruct.new(error?: true, error_message: 'something went wrong', page: 1)
+      def fetcher.call(*args); end
+      fetcher
     end
 
     PopulateIssuesJob.perform_now(repo)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require "capybara/rails"
-require 'webmock'
-
-WebMock.enable!
+require 'webmock/minitest'
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.


### PR DESCRIPTION
This commit gives a Fetcher the ability to pass in an optional retry parameter that will retry a request on failure. This works because random tokens are pulled for each request based off of the git_hub_bub initializer so if one token isn't good, try another for a few times before giving up.
