### PR TITLE
Decrease redis memory needs

### DIFF
--- a/app/jobs/background_inactive_email_job.rb
+++ b/app/jobs/background_inactive_email_job.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class BackgroundInactiveEmailJob < ApplicationJob
-  def perform(user, repos_by_need_ids: repos_by_need_ids)
+  def perform(user_or_id, repos_by_need_ids: repos_by_need_ids)
+    if user_or_id.is_a?(Integer)
+      user = User.find(user_or_id)
+    else
+      user = user_or_id
+    end
+
     return false if user.repo_subscriptions.present?
     UserMailer.poke_inactive(user: user, repos_by_need_ids: repos_by_need_ids).deliver_later
   end

--- a/app/jobs/populate_docs_job.rb
+++ b/app/jobs/populate_docs_job.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class PopulateDocsJob < ApplicationJob
-  def perform(repo)
+  def perform(repo_or_id)
+    if repo_or_id.is_a?(Integer)
+      repo = Repo.find(repo_or_id)
+    else
+      repo = repo_or_id
+    end
     repo.populate_docs!
   end
 end

--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class PopulateIssuesJob < ApplicationJob
-  def perform(repo)
+  def perform(repo_or_id)
+    if repo_or_id.is_a?(Integer)
+      repo = Repo.find(repo_or_id)
+    else
+      repo = repo_or_id
+    end
+
     @repo = repo
     populate_multi_issues!
   end

--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 class SendDailyTriageEmailJob < ApplicationJob
-  def perform(user, force_send: false)
+  def perform(user_or_id, force_send: false)
+    if user_or_id.is_a?(Integer)
+      user = User.find(user_or_id)
+    else
+      user = user_or_id
+    end
+
     return false if !force_send && skip?(user)
 
     send_daily_triage!(user)


### PR DESCRIPTION
- Store the raw ID instead of the global string-thingy in redis
- Only enqueue users that we know have at least have subscriptions. Ideally we would also pre-filter them for ready to receive an email, but we need to refactor some info out of repo_subscriptions so we don't end up with a ton of N+1 queries.
- Only select the info that we need in the queries (i.e. `select(:id)`) for less data transfer from the DB.
- Increase size of batch so that fewer queries need to be run

TODO store `last_sent_at` and `repo_subscriptions_count` metadata to users.