### PR TITLE
Mark Repos removed from GitHub

### DIFF
--- a/app/models/github_fetcher/resource.rb
+++ b/app/models/github_fetcher/resource.rb
@@ -29,6 +29,10 @@ module GithubFetcher
       call(retry_on_bad_token: retry_on_bad_token - 1)
     end
 
+    def status
+      response.status
+    end
+
     # Generally not over-ridden
     def as_json
       @as_json ||= response.json_body
@@ -46,14 +50,14 @@ module GithubFetcher
     end
 
     def success?
-      return true if response.status.to_s.start_with?("2")
+      return true if status.to_s.start_with?("2")
 
-      @error = @error_message = "Status: #{response.status} body: #{response.body}"
+      @error = @error_message = "Status: #{status} body: #{response.body}"
       false
     end
 
     def bad_token?
-      if response.status == 401 && response.body.match?(/Bad credentials/)
+      if status == 401 && response.body.match?(/Bad credentials/)
         @error = @error_message = "Bad credentials"
         return true
       end

--- a/db/migrate/20191017202913_add_removed_from_github_to_repo.rb
+++ b/db/migrate/20191017202913_add_removed_from_github_to_repo.rb
@@ -1,0 +1,5 @@
+class AddRemovedFromGithubToRepo < ActiveRecord::Migration[6.0]
+  def change
+    add_column :repos, :removed_from_github, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_14_201819) do
+ActiveRecord::Schema.define(version: 2019_10_17_202913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2019_10_14_201819) do
     t.integer "stars_count", default: 0
     t.integer "subscribers_count", default: 0
     t.integer "docs_subscriber_count", default: 0
+    t.boolean "removed_from_github", default: false
     t.index ["full_name"], name: "index_repos_on_full_name"
     t.index ["issues_count"], name: "index_repos_on_issues_count"
     t.index ["language"], name: "index_repos_on_language"


### PR DESCRIPTION
Right now we assume all Repos in Code Triage exist. This task will check each repo to see if it still exists, if not it will mark it for manual review.