### PR TITLE
Reduce DB load on application

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -930,7 +930,7 @@ GEM
       thor (>= 0.13.6)
     get_process_mem (0.2.4)
       ffi (~> 1.0)
-    git_hub_bub (1.0.0)
+    git_hub_bub (1.0.1)
       excon
       rrrretry
     globalid (0.4.2)

--- a/config/initializers/git_hub_bub.rb
+++ b/config/initializers/git_hub_bub.rb
@@ -9,11 +9,42 @@ GitHubBub::Request::GITHUB_VERSION = 'vnd.github.v3.full+json'
 GitHubBub::Request::USER_AGENT = 'codetriage'
 GitHubBub::Request::RETRIES = 3
 
+class CodeTraigeRandomApiKeyStore
+  def initialize
+    @keys = []
+    @mutex = Mutex.new
+  end
+
+  def call
+    return ENV['GITHUB_API_KEY'] if ENV['GITHUB_API_KEY']
+
+    until (key = @keys.pop)
+      populate_keys
+    end
+
+    return key
+  end
+
+  private def get_key
+    @keys.pop
+  end
+
+  private def populate_keys
+    @mutex.synchronize do
+      return if @keys.any?
+
+      @keys = User.order("RANDOM()").where.not(token: nil).limit(2000).pluck(:token)
+    end
+  end
+end
+
+code_triage_random_api_key_store = CodeTraigeRandomApiKeyStore.new
+
 # Auth all non authed requests (due to github request limits)
 GitHubBub::Request.set_before_callback do |request|
   if request.token?
     # Request is authorized, do nothing
   else
-    request.token = ENV['GITHUB_API_KEY'] || User.random.where.not(token: nil).select(:token).first.try(:token)
+    request.token = code_triage_random_api_key_store.call
   end
 end


### PR DESCRIPTION
Currently EVERY api request to GitHub results in a Query to the database. We can reduce this by a factor of 2000 by storing 2000 tokens in memory and updating them when we run out.

Also rev GitHubBub due to https://github.com/schneems/git_hub_bub/commit/650ec46fe284358e5f83a90a1070b2a9e837201
