### PR TITLE
Get rid of N+1 queries by using upsert_all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - 2.6.5
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 
 env:
   matrix:

--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -3,6 +3,7 @@
 class PopulateIssuesJob < RepoBasedJob
   def perform(repo)
     @repo = repo
+    @time_now = Time.now.utc
     populate_multi_issues!
   end
 
@@ -18,6 +19,18 @@ class PopulateIssuesJob < RepoBasedJob
 
   attr_reader :repo
 
+  def pr_attached_with_issue?(pull_request_hash)
+    # issue_hash['pull_request'] has following structure
+    #    pull_request: {
+    #                    html_url: null,
+    #                    diff_url: null,
+    #                    patch_url: null
+    #                  }
+    # When all the values are nil, PR is not attached with the issue
+    return false if pull_request_hash.blank?
+    pull_request_hash.values.uniq != [nil]
+  end
+
   def populate_issues(page_number)
     fetcher = repo.issues_fetcher
     fetcher.page = page_number
@@ -32,33 +45,24 @@ class PopulateIssuesJob < RepoBasedJob
         raise "Error grabbing issues status: #{fetcher.status}, repo_id: #{repo.id}.\nExpected result to be an array of hashes but is #{fetcher.as_json}"
       end
 
-      issue_number_to_github_hash = {}
+      upsert_mega_array = []
       fetcher.as_json.each do |github_issue_hash|
-        issue_number = github_issue_hash['number']
-        issue_number_to_github_hash[issue_number] = github_issue_hash
+        last_touched_at = github_issue_hash['updated_at'] ? DateTime.parse(github_issue_hash['updated_at']) : nil
+
+        upsert_mega_array << {
+          repo_id: @repo.id,
+          title: github_issue_hash['title'],
+          url: github_issue_hash['url'],
+          last_touched_at: last_touched_at,
+          state: github_issue_hash['state'],
+          html_url: github_issue_hash['html_url'],
+          number: github_issue_hash['number'],
+          pr_attached: pr_attached_with_issue?(github_issue_hash['pull_request'],
+          updated_at: @time_now)
+        }
       end
 
-      # Update issues that do exist
-      issues = Issue
-               .where("number in (?)", issue_number_to_github_hash.keys)
-               .where(repo_id: repo.id)
-
-      issues.each do |issue|
-        issue_hash = issue_number_to_github_hash.fetch(issue.number)
-        issue.update_from_github_hash!(issue_hash)
-      end
-
-      # TODO fix, some issues have duplicate numbers in tests
-      # We should ideally delete in the first loop
-      # but cannot for now due to tests
-      issues.each do |issue|
-        issue_number_to_github_hash.delete(issue.number)
-      end
-
-      # Create issues that didn't
-      issue_number_to_github_hash.each_value do |issue_hash|
-        Issue.create_from_github_hash!(issue_hash, repo: @repo)
-      end
+      Issue.upsert_all(upsert_mega_array, unique_by: [:number, :repo_id])
 
       !fetcher.last_page?
     end

--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -48,17 +48,18 @@ class PopulateIssuesJob < RepoBasedJob
       upsert_mega_array = []
       fetcher.as_json.each do |github_issue_hash|
         last_touched_at = github_issue_hash['updated_at'] ? DateTime.parse(github_issue_hash['updated_at']) : nil
+        pr_attached = pr_attached_with_issue?(github_issue_hash['pull_request'])
 
         upsert_mega_array << {
           repo_id: @repo.id,
           title: github_issue_hash['title'],
           url: github_issue_hash['url'],
-          last_touched_at: last_touched_at,
           state: github_issue_hash['state'],
           html_url: github_issue_hash['html_url'],
           number: github_issue_hash['number'],
-          pr_attached: pr_attached_with_issue?(github_issue_hash['pull_request'],
-          updated_at: @time_now)
+          pr_attached: pr_attached,
+          last_touched_at: last_touched_at,
+          updated_at: @time_now
         }
       end
 

--- a/db/migrate/20191025030201_add_unique_index_number_repo_id.rb
+++ b/db/migrate/20191025030201_add_unique_index_number_repo_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexNumberRepoId < ActiveRecord::Migration[6.0]
+  def change
+    add_index :issues, [:number, :repo_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_030201) do
+ActiveRecord::Schema.define(version: 2019_10_25_191255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_191255) do
+ActiveRecord::Schema.define(version: 2019_10_25_030201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_191255) do
     t.string "html_url"
     t.string "state"
     t.boolean "pr_attached", default: false
+    t.index ["number", "repo_id"], name: "index_issues_on_number_and_repo_id", unique: true
     t.index ["repo_id", "id"], name: "index_issues_on_repo_id_and_id", where: "((state)::text = 'open'::text)"
     t.index ["repo_id", "number"], name: "index_issues_on_repo_id_and_number"
     t.index ["repo_id", "state"], name: "index_issues_on_repo_id_and_state"

--- a/test/fixtures/issues.yml
+++ b/test/fixtures/issues.yml
@@ -18,7 +18,7 @@ issue_two:
   repo_name:
   user_name:
   last_touched_at: 2012-11-10 22:20:24.000000000 Z
-  number: 1
+  number: 2
   created_at: 2012-11-10 23:23:45.281189000 Z
   updated_at: 2012-11-10 23:23:45.281189000 Z
   repo_id: 3
@@ -32,7 +32,7 @@ issue_three:
   repo_name:
   user_name:
   last_touched_at: 2012-11-10 22:20:24.000000000 Z
-  number: 1
+  number: 3
   created_at: 2012-11-10 23:23:45.281189000 Z
   updated_at: 2012-11-10 23:23:45.281189000 Z
   repo_id: 3
@@ -46,7 +46,6 @@ issue_triage_sandbox_issue:
   comment_count:
   url: https://api.github.com/repos/bemurphy/issue_triage_sandbox/issues/1
   last_touched_at: 2012-11-10 22:20:24.000000000 Z
-  number: 1
   created_at: 2012-11-10 23:23:45.281189000 Z
   updated_at: 2012-11-10 23:23:45.281189000 Z
   repo: issue_triage_sandbox
@@ -60,7 +59,6 @@ issue_five_extra_long_title:
   comment_count:
   url: https://api.github.com/repos/bemurphy/issue_triage_sandbox/issues/1
   last_touched_at: 2012-11-10 22:20:24.000000000 Z
-  number: 1
   created_at: 2012-11-10 23:23:45.281189000 Z
   updated_at: 2012-11-10 23:23:45.281189000 Z
   repo: issue_triage_sandbox

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,7 @@ OmniAuth.config.add_mock(:github, {
 VCR.configure do |c|
   # This 'allow' should be temporary, work towards covering
   # everything via vcr because github rate limits
-  c.allow_http_connections_when_no_cassette = true
+  c.allow_http_connections_when_no_cassette = false
   c.cassette_library_dir = 'test/vcr_cassettes'
   c.hook_into :webmock
 

--- a/test/unit/issue_assignment_test.rb
+++ b/test/unit/issue_assignment_test.rb
@@ -59,13 +59,13 @@ class IssueAssignmentTest < ActiveSupport::TestCase
 
     repo.issues.each do |issue|
       stub_request(:get, %r{https://api.github.com/repos/bemurphy/issue_triage_sandbox/issues/#{issue.number}})
-       .to_return({ body: issue.as_json.to_json, status: 200})
+        .to_return({ body: issue.as_json.to_json, status: 200 })
 
       stub_request(:get, %r{https://api.github.com/repos/bemurphy/issue_triage_sandbox/issues/#{issue.number}/comments})
         .to_return({
-          body: [{ "id" => 5, "user" => { "login" => "rtomayko", "id" => 404 } }].to_json,
-          status: 200
-        })
+                     body: [{ "id" => 5, "user" => { "login" => "rtomayko", "id" => 404 } }].to_json,
+                     status: 200
+                   })
     end
 
     assigner = IssueAssigner.new(user, [sub], can_access_network: true)

--- a/test/unit/issue_test.rb
+++ b/test/unit/issue_test.rb
@@ -116,7 +116,8 @@ class IssueTest < ActiveSupport::TestCase
     repo.issues.new(state: 'closed')
 
     2.times do
-      open_issues << repo.issues.create!(state: 'open', number: 42)
+      number = Issue.maximum(:number) + 1
+      open_issues << repo.issues.create!(state: 'open', number: number)
     end
 
     assert_equal open_issues, repo.open_issues.order(:created_at)

--- a/test/vcr_cassettes/fetch_issue_comments.yml
+++ b/test/vcr_cassettes/fetch_issue_comments.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/sinatra/sinatra/issues/1/comments
+    uri: https://api.github.com/repos/sinatra/sinatra/issues/3/comments
     body:
       encoding: US-ASCII
       string: ''
@@ -69,7 +69,7 @@ http_interactions:
       - DB73:2B2E9:1098AF0:1561DC0:59658634
     body:
       encoding: UTF-8
-      string: '[{"url":"https://api.github.com/repos/sinatra/sinatra/issues/comments/5","html_url":"https://github.com/sinatra/sinatra/issues/1#issuecomment-5","issue_url":"https://api.github.com/repos/sinatra/sinatra/issues/1","id":5,"user":{"login":"rtomayko","id":404,"avatar_url":"https://avatars0.githubusercontent.com/u/404?v=3","gravatar_id":"","url":"https://api.github.com/users/rtomayko","html_url":"https://github.com/rtomayko","followers_url":"https://api.github.com/users/rtomayko/followers","following_url":"https://api.github.com/users/rtomayko/following{/other_user}","gists_url":"https://api.github.com/users/rtomayko/gists{/gist_id}","starred_url":"https://api.github.com/users/rtomayko/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rtomayko/subscriptions","organizations_url":"https://api.github.com/users/rtomayko/orgs","repos_url":"https://api.github.com/users/rtomayko/repos","events_url":"https://api.github.com/users/rtomayko/events{/privacy}","received_events_url":"https://api.github.com/users/rtomayko/received_events","type":"User","site_admin":false},"created_at":"2009-03-06T21:35:42Z","updated_at":"2009-03-06T21:35:42Z","body":"+1\n"}]'
-    http_version: 
+      string: '[{"url":"https://api.github.com/repos/sinatra/sinatra/issues/comments/5","html_url":"https://github.com/sinatra/sinatra/issues/3#issuecomment-5","issue_url":"https://api.github.com/repos/sinatra/sinatra/issues/3","id":5,"user":{"login":"rtomayko","id":404,"avatar_url":"https://avatars0.githubusercontent.com/u/404?v=3","gravatar_id":"","url":"https://api.github.com/users/rtomayko","html_url":"https://github.com/rtomayko","followers_url":"https://api.github.com/users/rtomayko/followers","following_url":"https://api.github.com/users/rtomayko/following{/other_user}","gists_url":"https://api.github.com/users/rtomayko/gists{/gist_id}","starred_url":"https://api.github.com/users/rtomayko/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/rtomayko/subscriptions","organizations_url":"https://api.github.com/users/rtomayko/orgs","repos_url":"https://api.github.com/users/rtomayko/repos","events_url":"https://api.github.com/users/rtomayko/events{/privacy}","received_events_url":"https://api.github.com/users/rtomayko/received_events","type":"User","site_admin":false},"created_at":"2009-03-06T21:35:42Z","updated_at":"2009-03-06T21:35:42Z","body":"+1\n"}]'
+    http_version:
   recorded_at: Wed, 12 Jul 2017 02:15:17 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Previously we were loading and instantiating issues for every issue pulled from GitHub. With this patch we no longer create issue objects and we've removed the N+1 query for the case where new issues are created.

All updates and creates are now done via `upsert_all`. To accomplish this we need a unique index on [:number, :repo_id] for issues.

cc/ @nateberkopec
