### PR TITLE
Speed up query by adding index

### DIFF
--- a/db/migrate/20191025191255_add_updated_at_index_to_issues.rb
+++ b/db/migrate/20191025191255_add_updated_at_index_to_issues.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtIndexToIssues < ActiveRecord::Migration[6.0]
+  def change
+    add_index :issues, :updated_at, where: "state = '#{Issue::OPEN}'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_17_202913) do
+ActiveRecord::Schema.define(version: 2019_10_25_191255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 2019_10_17_202913) do
     t.index ["repo_id", "id"], name: "index_issues_on_repo_id_and_id", where: "((state)::text = 'open'::text)"
     t.index ["repo_id", "number"], name: "index_issues_on_repo_id_and_number"
     t.index ["repo_id", "state"], name: "index_issues_on_repo_id_and_state"
+    t.index ["updated_at"], name: "index_issues_on_updated_at", where: "((state)::text = 'open'::text)"
   end
 
   create_table "repo_subscriptions", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
 end
 
 begin
-  Timeout.timeout(5) do
+  Timeout.timeout(10) do
     user = User.where(github: "schneems").first_or_create!
     repo = Repo.where(user_name: "schneems", name: "get_process_mem", language: "Ruby").first_or_create!(skip_validation: true)
     user.repo_subscriptions.where(repo: repo, read: true, read_limit: 3, email_limit: 3).first_or_create!


### PR DESCRIPTION
When pairing for a bit @nateberkopec thought that one of the queries in our `heroku pg:outliers` might not have an index:

```
 00:06:22.833704 | 11.1%          | 10        | 00:04:58.761044 | UPDATE "issues" SET "state" = $1 WHERE (state = $2 and updated_at < $3)
```

When we checked, sure enough it didn't have an index on `updated_at`

```
issuetriage::DATABASE=> \d issues
# ...
Indexes:
    "issues_pkey" PRIMARY KEY, btree (id)
    "index_issues_on_repo_id_and_id" btree (repo_id, id) WHERE state::text = 'open'::text
    "index_issues_on_repo_id_and_number" btree (repo_id, number)
    "index_issues_on_repo_id_and_state" btree (repo_id, state)
```

However when we tried adding one, it didn't actually help. Here's the explain analyze before.

```
issuetriage::DATABASE=> EXPLAIN ANALYZE SELECT count(*) FROM issues WHERE (state = 'open' and updated_at < NOW() - interval '24 hours');
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=105562.86..105562.86 rows=1 width=8) (actual time=290.238..290.238 rows=1 loops=1)
   ->  Bitmap Heap Scan on issues  (cost=3470.06..105486.69 rows=152340 width=0) (actual time=44.423..279.502 rows=151458 loops=1)
         Recheck Cond: ((state)::text = 'open'::text)
         Filter: (updated_at < (now() - '24:00:00'::interval))
         Rows Removed by Filter: 267773
         Heap Blocks: exact=72308
         ->  Bitmap Index Scan on index_issues_on_repo_id_and_id  (cost=0.00..3462.44 rows=152355 width=0) (actual time=30.103..30.103 rows=419237 loops=1)
 Planning time: 0.121 ms
 Execution time: 290.278 ms
(9 rows)
```

Then we manually added an index:

```sql
issuetriage::DATABASE=> CREATE INDEX issues_index_update_at_blerg
issuetriage::DATABASE-> ON issues (updated_at);
```

When we ran again, postgres wasn't using our index (identical query plan):

```
issuetriage::DATABASE=> EXPLAIN ANALYZE SELECT count(*) FROM issues WHERE (state = 'open' and updated_at < NOW() - interval '24 hours');
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=105562.31..105562.31 rows=1 width=8) (actual time=294.793..294.793 rows=1 loops=1)
   ->  Bitmap Heap Scan on issues  (cost=3470.01..105486.64 rows=151336 width=0) (actual time=44.215..283.601 rows=151458 loops=1)
         Recheck Cond: ((state)::text = 'open'::text)
         Filter: (updated_at < (now() - '24:00:00'::interval))
         Rows Removed by Filter: 267773
         Heap Blocks: exact=72308
         ->  Bitmap Index Scan on index_issues_on_repo_id_and_id  (cost=0.00..3462.44 rows=152355 width=0) (actual time=29.875..29.875 rows=419237 loops=1)
 Planning time: 0.155 ms
 Execution time: 294.834 ms
(9 rows)
```

We wondered why it was using `index_issues_on_repo_id_and_id` since neither ID or repo_id was in our query. It turns out this is a partial index, only where the issue is marked as "open"

```
"index_issues_on_repo_id_and_id" btree (repo_id, id) WHERE state::text = 'open'::text
```

Essentially postgres was using it as a shortcut to filter out issues that were closed. We had a theory that perhaps if we mad e our index a partial index as well then Postgres would realize it could get all the info it needed from one single index:


```sql
issuetriage::DATABASE=> CREATE INDEX issues_index_update_at_blerg
issuetriage::DATABASE-> ON issues (updated_at)
issuetriage::DATABASE-> WHERE state::text = 'open'::text;
```

When we did this, the query is twice as fast:

```
issuetriage::DATABASE=> EXPLAIN ANALYZE SELECT count(*) FROM issues WHERE (state = 'open' and updated_at < NOW() - interval '24 hours');
                                                                           QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=18539.98..18539.99 rows=1 width=8) (actual time=123.444..123.445 rows=1 loops=1)
   ->  Index Only Scan using issues_index_update_at_blerg on issues  (cost=0.09..18463.81 rows=152340 width=0) (actual time=0.098..112.576 rows=151458 loops=1)
         Index Cond: (updated_at < (now() - '24:00:00'::interval))
         Heap Fetches: 105432
 Planning time: 0.263 ms
 Execution time: 123.478 ms
```

I then dropped the index and this commit adds a migration so that the index is tracked in the Rails codebase.
