### PR TITLE
The `fork` call screws with Scout/Skylight and friends

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -62,10 +62,8 @@ class Repo < ActiveRecord::Base
     location ||= fetcher.clone
 
     parser = class_for_doc_language.new(location)
-    parser.in_fork do
-      parser.process
-      parser.store(self)
-    end
+    parser.process
+    parser.store(self)
     return :success
   end
 

--- a/test/unit/repo_test.rb
+++ b/test/unit/repo_test.rb
@@ -104,20 +104,6 @@ class RepoTest < ActiveSupport::TestCase
     end
   end
 
-  test "#populate_docs!" do
-    repo = repos(:rails_rails)
-
-    VCR.use_cassette "repo_populate_docs" do
-      double = Object.new
-      DocsDoctor::Parsers::Ruby::Yard.stub(:new, ->(_) { double }) do
-        double.expects(:in_fork)
-        assert_nil repo.commit_sha
-        repo.populate_docs!(has_subscribers: true)
-        assert_not_nil repo.commit_sha
-      end
-    end
-  end
-
   test '.without_user_subscriptions' do
     user = users(:schneems)
     subscribed_repo = user.repo_subscriptions.first


### PR DESCRIPTION
I like the behavior but want to disable to get some metrics so we can fix the underlying memory problem rather than cover it up with a fork.
