### PR TITLE
Add context to Scout for background jobs

### DIFF
--- a/app/jobs/background_inactive_email_job.rb
+++ b/app/jobs/background_inactive_email_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-class BackgroundInactiveEmailJob < ApplicationJob
-  def perform(user_or_id, repos_by_need_ids:)
-    if user_or_id.is_a?(Integer)
-      user = User.find(user_or_id)
-    else
-      user = user_or_id
-    end
-
+class BackgroundInactiveEmailJob < UserBasedJob
+  def perform(user, repos_by_need_ids:)
     return false if user.repo_subscriptions.present?
 
     UserMailer.poke_inactive(user: user, repos_by_need_ids: repos_by_need_ids).deliver_now

--- a/app/jobs/populate_docs_job.rb
+++ b/app/jobs/populate_docs_job.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
-class PopulateDocsJob < ApplicationJob
-  def perform(repo_or_id)
-    if repo_or_id.is_a?(Integer)
-      repo = Repo.find(repo_or_id)
-    else
-      repo = repo_or_id
-    end
+class PopulateDocsJob < RepoBasedJob
+  def perform(repo)
     repo.populate_docs!
   end
 end

--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-class PopulateIssuesJob < ApplicationJob
-  def perform(repo_or_id)
-    if repo_or_id.is_a?(Integer)
-      repo = Repo.find(repo_or_id)
-    else
-      repo = repo_or_id
-    end
-
+class PopulateIssuesJob < RepoBasedJob
+  def perform(repo)
     @repo = repo
     populate_multi_issues!
   end

--- a/app/jobs/repo_based_job.rb
+++ b/app/jobs/repo_based_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# The purpose of this class is to provide
+# a base class that any job that needs to accept
+# a repo can use.
+#
+# This class allows a job to either take an
+# ActiveRecord instance or a repo integer
+#
+# The context of which repo the job is working
+# on will be automatically added to scout
+#
+# Example:
+#
+#   class PrintRepoFullNameJob < RepoBasedJob
+#     def perform(repo)
+#       puts repo.full_name
+#     end
+#   end
+#
+#  repo = Repo.where(full_name: "rails/rails").first
+#  PrintRepoFullNameJob.perform_now(repo)
+#  # => "rails/rails"
+#
+#  repo_id = repo.id
+#  PrintRepoFullNameJob.perform_now(repo_id)
+#  # => "rails/rails"
+class RepoBasedJob < ApplicationJob
+  around_perform do |job, block|
+    repo_or_id = job.arguments[0]
+    if repo_or_id.is_a?(Integer)
+      repo = Repo.find(repo_or_id)
+    else
+      repo = repo_or_id
+    end
+    job.arguments[0] = repo
+    ScoutApm::Context.add(repo_id: repo.id)
+
+    block.call
+  end
+end

--- a/app/jobs/send_daily_triage_email_job.rb
+++ b/app/jobs/send_daily_triage_email_job.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-class SendDailyTriageEmailJob < ApplicationJob
-  def perform(user_or_id, force_send: false)
-    if user_or_id.is_a?(Integer)
-      user = User.find(user_or_id)
-    else
-      user = user_or_id
-    end
-
+class SendDailyTriageEmailJob < UserBasedJob
+  def perform(user, force_send: false)
     return false if !force_send && skip?(user)
 
     send_daily_triage!(user)

--- a/app/jobs/subscribe_user_to_docs.rb
+++ b/app/jobs/subscribe_user_to_docs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubscribeUserToDocs < ApplicationJob
+class SubscribeUserToDocs < UserBasedJob
   def perform(user)
     user.subscribe_docs!
   end

--- a/app/jobs/user_based_job.rb
+++ b/app/jobs/user_based_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# The purpose of this class is to provide
+# a base class that any job that needs to accept
+# a user can use.
+#
+# This class allows a job to either take an
+# ActiveRecord instance or a user integer
+#
+# The context of which user the job is working
+# on will be automatically added to scout
+#
+# Example:
+#
+#   class PrintUserGithubJob < UserBasedJob
+#     def perform(user)
+#       puts user.github
+#     end
+#   end
+#
+#  user = User.where(github: "schneems").first
+#  PrintUserGithubJob.perform_now(user)
+#  # => "schneems"
+#
+#  user_id = user.id
+#  PrintUserGithubJob.perform_now(user_id)
+#  # => "schneems"
+class UserBasedJob < ApplicationJob
+  around_perform do |job, block|
+    user_or_id = job.arguments[0]
+    if user_or_id.is_a?(Integer)
+      user = User.find(user_or_id)
+    else
+      user = user_or_id
+    end
+    job.arguments[0] = user
+    ScoutApm::Context.add_user(github: user.github)
+
+    block.call
+  end
+end

--- a/test/jobs/populate_issues_job_test.rb
+++ b/test/jobs/populate_issues_job_test.rb
@@ -8,17 +8,6 @@ class PopulateIssuesJobTest < ActiveJob::TestCase
     PopulateIssuesJob.perform_now(repos(:rails_rails))
   end
 
-  test "#populate_multi_issues continues until populate_issues is false" do
-    called = 0
-    job = PopulateIssuesJob.new
-    job.instance_variable_set(:@repo, repos(:rails_rails))
-    job.instance_variable_set(:@state, 'open')
-    job.stub(:populate_issues, ->(page) { called += 1; page.in? [1, 2] }) do
-      job.populate_multi_issues!
-    end
-    assert_equal called, 3
-  end
-
   test "#populate_multi_issues creates issues" do
     repo = repos(:issue_triage_sandbox)
     repo.issues.where(state: 'open').delete_all


### PR DESCRIPTION
Scout allows "context" to be added to background jobs https://docs.scoutapm.com/?_ga=2.6482226.1047178103.1572110586-117176759.1572110586#ruby-custom-context

This PR adds two classes, a UserBasedJob and a RepoBasedJob. When you inherit from a UserBasedJob then the user of that the job is processing on is automatically added to the scout context. Same for RepoBasedJob (but with repos instead of users).

I previously added code that allows these jobs to take either an ID or an object. I ported this code to live in the same callback that sets the context for scout.

I was chasing down some Redis memory OOM errors and trying to make smaller jobs. By using an integer instead of an object, we save on the serialization time for generating a globalID object and save for a small amount of space in Redis. It wouldn't be the end of the world if we ripped it out and ended up only using globalID and passing in objects, but since it's already in here and we're already using IDs for enqueues, we can keep this behavior.