### PR TITLE
Attempt to Reduce memory requirements of Doc Parse

### DIFF
--- a/app/jobs/populate_docs_job.rb
+++ b/app/jobs/populate_docs_job.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class PopulateDocsJob < RepoBasedJob
+  around_perform do |_job, block|
+    ActiveRecord::Base.uncached do
+      block.call
+    end
+  end
+
   def perform(repo)
     repo.populate_docs!
   end


### PR DESCRIPTION
When parsing documentation we generate a lot of active record objects:

![](https://www.dropbox.com/s/3r9l7zdgbmz86mk/Screenshot%202019-10-26%2013.27.00.png?raw=1)

![](https://www.dropbox.com/s/dttmiea6vh0il9c/Screenshot%202019-10-26%2013.25.33.png?raw=1)

Most of them are only needed for a split second or two and can then be collected, however due to the QueryCache the objects will live on in memory for the entire duration of the job:

- https://github.com/rails/rails/issues/27002
- https://github.com/rails/rails/issues/28646

This PR disables the Query cache for the populate docs job. 

In the future we need to remove all these N+1 queries from the background doc parse, but for now hopefully this bandaid will at least prevent N+1 objects from being retained in memory for the duration of the job.
