### PR TITLE
Schneems/guard empty upsert

### DIFF
--- a/app/jobs/populate_issues_job.rb
+++ b/app/jobs/populate_issues_job.rb
@@ -52,19 +52,21 @@ class PopulateIssuesJob < RepoBasedJob
 
         upsert_mega_array << {
           repo_id: @repo.id,
+          pr_attached: pr_attached,
+          last_touched_at: last_touched_at,
+          updated_at: @time_now,
+          created_at: @time_now,
           title: github_issue_hash['title'],
           url: github_issue_hash['url'],
           state: github_issue_hash['state'],
           html_url: github_issue_hash['html_url'],
-          number: github_issue_hash['number'],
-          pr_attached: pr_attached,
-          last_touched_at: last_touched_at,
-          updated_at: @time_now,
-          created_at: @time_now
+          number: github_issue_hash['number']
         }
       end
 
-      Issue.upsert_all(upsert_mega_array, unique_by: [:number, :repo_id])
+      if upsert_mega_array.any?
+        Issue.upsert_all(upsert_mega_array, unique_by: [:number, :repo_id])
+      end
 
       !fetcher.last_page?
     end

--- a/test/jobs/populate_issues_job_test.rb
+++ b/test/jobs/populate_issues_job_test.rb
@@ -8,6 +8,15 @@ class PopulateIssuesJobTest < ActiveJob::TestCase
     PopulateIssuesJob.perform_now(repos(:rails_rails))
   end
 
+  test "Works when there's no issues" do
+    stub_request(:any, "https://api.github.com/repos/bemurphy/issue_triage_sandbox/issues?direction=desc&page=1&sort=comments&state=open")
+      .to_return({ body: [].to_json, status: 200 })
+
+    repo = repos(:issue_triage_sandbox)
+
+    PopulateIssuesJob.perform_now(repo)
+  end
+
   test "#populate_multi_issues creates issues" do
     repo = repos(:issue_triage_sandbox)
     repo.issues.where(state: 'open').delete_all


### PR DESCRIPTION
Fix ArgumentError Empty list of attributes passed

When you try to call upsert with an empty array: 

```
Issue.upsert_all([], unique_by: [:number, :repo_id])
```

You get an error:

```
ArgumentError: Empty list of attributes passed
    app/jobs/populate_issues_job.rb:68:in `populate_issues'
```

This commit guards against this case by checking for an empty array and also adds a test ensuring this case continues to work.