### PR TITLE
Fix trailing blank line

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,4 +121,3 @@ gem 'barnes'
 gem 'puma_worker_killer'
 gem 'rake'
 gem 'rails_autoscale_agent'
-


### PR DESCRIPTION
From rubocop:

Gemfile:124:1: C: Layout/TrailingBlankLines: 1 trailing blank lines detected.