### PR TITLE
Disable collection caching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     css_parser (1.7.0)
       addressable
     dalli (2.7.10)
-    derailed_benchmarks (1.4.3)
+    derailed_benchmarks (1.5.0)
       benchmark-ips (~> 2)
       get_process_mem (~> 0)
       heapy (~> 0)

--- a/app/views/pages/_repos_with_pagination.html.slim
+++ b/app/views/pages/_repos_with_pagination.html.slim
@@ -1,2 +1,2 @@
-ul.repo-list = render partial: "repos/repo", collection: repos, cached: true
+ul.repo-list = render partial: "repos/repo", collection: repos, cached: false
 .pagination= will_paginate repos, container: false


### PR DESCRIPTION
By disabling collection caching we can significantly improve the performance of the home page. Performance improvements across 5 different runs range from `1.40x` to `1.58x`. All tests were statistically significant with a confidence interval of 99%. I am extremely confident in these results:

```
$ DERAILED_PATH_TO_LIBRARY=. bundle exec derailed exec perf:library

❤️ ❤️ ❤️  (Statistically Significant) ❤️ ❤️ ❤️

[70736f8] "Disable collection caching" - (4.115744 seconds)
  FASTER 🚀🚀🚀 by:
     1.5219x [older/newer]
    34.2936% [(older - newer) / older * 100]
[ad28f58] "Comment out statsd as well" - (6.2638365 seconds)

Iterations per sample: 200
Samples: 200

Test type: Kolmogorov Smirnov
Confidence level: 99.0 %
Is significant? (max > critical): true
D critical: 0.15174271293851463
D max: 0.83

Output: tmp/compare_branches/2019-12-31-02-24-1577780694-570399000/results.txt
```

## Why? 

Why does _disabling_ caching make things faster? Generating cache keys for all fragments and retrieving the results and doing book-keeping to make sure it's all working as intended/expected is very expensive.

I have two PRs that are trying to speed this up in rails:

- https://github.com/rails/rails/pull/36310
- https://github.com/rails/rails/pull/37301

Both of these are effectively doing the same thing but in different ways, which is to make the generation of cache keys for fragments cheaper.

Even if these patches are merged, disabling caching here would still be faster. Why?

The partials being cached are REALLY tiny, here's an example:

```slim
li class="repo-item #{ repo.weight }" data-language="#{ repo.language if repo.language }"
  = link_to repo
    header.repo-item-header
      h3.repo-item-title = repo.name
      span.repo-item-issues
        span.warning-svg.issue-icon
        = repo.issues_count
        |  Issues

    p.repo-item-description = repo.description

    - if repo.full_name.present?
      span.repo-item-full-name
        | (#{repo.full_name})
```

While we do have to go through some logic and render some values from the `repo` object, it's not really doing all that much. In comparison when we're trying to use collection caching, we have to build a cache key for each object, then for the combination of view/object, then query our cache store, and then map the results back to the view. Even in the case where all fragments are already in cache, this is still slower than just rendering each fragment manually.

**TLDR;** Collection caching is hella expensive, only use it in cases where fragments are even _more_ expensive. It might be nice to add some kind of local performance profiling to indicate to developers when it is "worth it".