### PR TITLE
Disallow invalid characters in repo name from GH

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -34,6 +34,7 @@ class ReposController < RepoBasedController
 
   def create
     parse_params_for_repo_info
+    check_params
     @repo   = Repo.search_by(params[:repo][:name], params[:repo][:user_name]).first unless params_blank?
     @repo ||= Repo.new(repo_params)
     if @repo.save
@@ -121,6 +122,14 @@ class ReposController < RepoBasedController
       params[:repo][:name]      = url_array.pop || ""
       params[:repo][:user_name] = url_array.pop || ""
     end
+  end
+
+  def check_params
+    flash[:error] = "Invalid Github repo or username." if invalid_char?(params[:repo][:user_name]) || invalid_char?(params[:repo][:name])
+  end
+
+  def invalid_char?(param)
+    !!(param =~ /[?=]/)
   end
 
   def params_blank?

--- a/test/functional/repos_controller_test.rb
+++ b/test/functional/repos_controller_test.rb
@@ -20,6 +20,11 @@ class ReposControllerTest < ActionController::TestCase
     assert_redirected_to user_github_omniauth_authorize_path(origin: "/repos")
   end
 
+  test 'responds with flash error message if repo name contains invalid characters (?=)' do
+    post :create, params: { repo: { name: 'codetriage', user_name: 'codetriage?=1' } }
+    assert_equal flash[:error], "Invalid Github repo or username."
+  end
+
   test 'do not send email for repo without issues' do
     sign_in users(:mockstar)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Solving https://github.com/codetriage/codetriage/issues/1145: 

Disallow invalid characters such as ?= in a username/name parameter. Throw error safely and exit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
