### PR TITLE
Bump rubocop from 0.76.0 to 0.79.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,13 +12,13 @@ AllCops:
     - 'perf_scripts/**/*'
     - 'scratch.rb'
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
  Enabled: true
 
-Layout/AlignHash:
+Layout/HashAlignment:
  Enabled: true
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
  Enabled: true
 
 Layout/BlockEndNewline:
@@ -51,10 +51,10 @@ Layout/EmptyLinesAroundClassBody:
 Layout/ExtraSpacing:
  Enabled: true
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
  Enabled: true
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
  Enabled: true
 
 Layout/IndentationConsistency:
@@ -119,7 +119,7 @@ Layout/SpaceInsideParens:
 Layout/SpaceInsideStringInterpolation:
  Enabled: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
  Enabled: true
 
 Layout/TrailingWhitespace:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,8 +249,8 @@ GEM
       omniauth (~> 1.9)
     optimist (3.0.0)
     orm_adapter (0.5.0)
-    parallel (1.19.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     pdf-core (0.7.0)
     pg (1.2.0)
@@ -330,10 +330,10 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rrrretry (1.0.0)
-    rubocop (0.76.0)
+    rubocop (0.79.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
@@ -405,7 +405,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     uniform_notifier (1.13.0)
     valid_email (0.1.3)
       activemodel
@@ -518,4 +518,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR just updates the Rubocop version

## Related Issue
#1239 
