### PR TITLE
[Close #1145] Updated new repo URL parsing logic 

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -113,14 +113,13 @@ class ReposController < RepoBasedController
   def parse_params_for_repo_info
     return unless params[:url]
     params[:repo] ||= {}
-    if params[:url] =~ /^https:\/\/github\.com\/([^\/]*)\/([^\/]*)\/?$/
-      params[:repo][:user_name] = $1.to_s
-      params[:repo][:name]      = $2.to_s
-    else
-      url_array = params[:url].split("/")
-      params[:repo][:name]      = url_array.pop || ""
-      params[:repo][:user_name] = url_array.pop || ""
-    end
+
+    params[:url].gsub!(/(.*)github\.com\//, "")
+    params[:url].gsub!(/\?(.*)/, "")
+
+    url_array = params[:url].split("/")
+    params[:repo][:name]      = url_array.pop || ""
+    params[:repo][:user_name] = url_array.pop || ""
   end
 
   def params_blank?

--- a/test/integration/adding_repos_test.rb
+++ b/test/integration/adding_repos_test.rb
@@ -23,6 +23,38 @@ class AddingReposTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "modifies the URL when it has invalid params" do
+    login_via_github
+    VCR.use_cassette('my_repos') do
+      visit "/"
+      click_link "Submit a Repo"
+
+      fill_in 'url', with: 'https://github.com/bemurphy/issue_triage_sandbox?files=1'
+
+      click_button "Add Repo"
+    end
+
+    VCR.use_cassette('add_valid_repo') do
+      assert page.has_content?("Added bemurphy/issue_triage_sandbox for triaging")
+    end
+  end
+
+  test "supports URL without github.com" do
+    login_via_github
+    VCR.use_cassette('my_repos') do
+      visit "/"
+      click_link "Submit a Repo"
+
+      fill_in 'url', with: 'bemurphy/issue_triage_sandbox'
+
+      click_button "Add Repo"
+    end
+
+    VCR.use_cassette('add_valid_repo') do
+      assert page.has_content?("Added bemurphy/issue_triage_sandbox for triaging")
+    end
+  end
+
   test "adding invalid repo with blank params" do
     login_via_github
     VCR.use_cassette('blank_repo') do
@@ -34,17 +66,4 @@ class AddingReposTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? "can't be blank"
   end
-
-  # TODO: Pending for now but we should enable this, there's an env change in repo that
-  # treats all repo urls as valid in test.  Fix this one that is removed
-  # test "adding an invalid repo" do
-  #   VCR.use_cassette('add_invalid_repo') do
-  #     visit "/"
-  #     click_link "Add a Repo"
-  #     fill_in 'repo_user_name', with: 'bemurphy'
-  #     fill_in 'repo_name', with: 'issue_triage_bogus_repo'
-  #     click_button "Add Repo"
-  #     assert page.has_content?("you mistyped something?")
-  #   end
-  # end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow support for different types of URL including: 
```schneems/wicked
github.com/schneems/wicked
https://github.com/schneems/wicked"
https://github.com/schneems/wicked?files=1" # strip out everything after the ?```
