### PR TITLE
Fix/covid language bug

### DIFF
--- a/app/assets/javascripts/homepage.js
+++ b/app/assets/javascripts/homepage.js
@@ -1,15 +1,15 @@
 // JS for the buttons on the home page
 $(document).ready(function(){
   $(".types-filter-button").click(function() {
-    $(".types-filter").toggle();
+    $(this).parent().find('.types-filter').toggle();
   });
 
   $(".types-filter > li a").click(function(e){
     e.preventDefault();
 
-    $(".types-filter").hide();
+    $(this).parent().parent().parent().find(".types-filter").hide();
     var language = this.getAttribute("data-language");
-    $(".types-filter-button").html(language);
+    $(this).parent().parent().parent().find(".types-filter-button").html(language);
     updateQueryStringParam("language", language);
     removeQueryStringParam("page");
     document.location = document.URL;

--- a/app/assets/javascripts/homepage.js
+++ b/app/assets/javascripts/homepage.js
@@ -10,7 +10,8 @@ $(document).ready(function(){
     $(this).parent().parent().parent().find(".types-filter").hide();
     var language = this.getAttribute("data-language");
     $(this).parent().parent().parent().find(".types-filter-button").html(language);
-    updateQueryStringParam("language", language);
+    var queryKey = this.getAttribute("data-query");
+    updateQueryStringParam(queryKey, language);
     removeQueryStringParam("page");
     document.location = document.URL;
 //     $.ajax({

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -17,13 +17,13 @@
     label.types-filter-label Filter list<span> by Language</span>:
     = render "down"
     a.types-filter-button
-      = params["language"] || "Select Language"
+      = params["language_covid"] || "Select Language"
 
     ul.types-filter
       = cache(:language_list, expires_in: 1.hour) do
         - Repo.select("DISTINCT language").map(&:language).compact.sort.each do |lang|
           - unless lang.nil?
-            li = link_to lang, "#", data: { toggle: "tab", language: lang }
+            li = link_to lang, "#", data: { toggle: "tab", language: lang, query: "language_covid" }
 
   section.repo-list-with-pagination
     = render "repos_with_pagination", repos: @covid_repos
@@ -55,7 +55,7 @@ hr.section-break
       = cache(:language_list, expires_in: 1.hour) do
         - Repo.select("DISTINCT language").map(&:language).compact.sort.each do |lang|
           - unless lang.nil?
-            li = link_to lang, "#", data: { toggle: "tab", language: lang }
+            li = link_to lang, "#", data: { toggle: "tab", language: lang, query: "language" }
 
   section.repo-list-with-pagination
     = render "repos_with_pagination", repos: @repos

--- a/test/integration/filtering_language_test.rb
+++ b/test/integration/filtering_language_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FilteringLanguageTest < ActionDispatch::IntegrationTest
+  teardown do
+    Rails.cache.clear
+  end
+
+  test "filtering language in covid projects" do
+    visit "/?language_covid=Ruby"
+
+    assert_equal page.all('.types-filter-button')[0].text, 'Ruby'
+    assert_equal page.all('.types-filter-button')[1].text, 'Select Language'
+  end
+
+  test "filtering language in normal projects" do
+    visit "/?language=Ruby"
+
+    assert_equal page.all('.types-filter-button')[0].text, 'Select Language'
+    assert_equal page.all('.types-filter-button')[1].text, 'Ruby'
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hello Guys! I found a bug in new homepage. The bug was caused because the new area of covid. Now, are two projects filters, one just for covid related projects and another for the normal projects, so the both filters were synced, like you change a value from one input, the another will change too. Besides that when you open a filter, the another opens too.

## Related Issue
#1294 

## Motivation and Context
Fix the bug.

## Screenshots (if appropriate):
Before:
![Peek 2020-05-07 16-51](https://user-images.githubusercontent.com/49662698/81338907-c2b55280-9083-11ea-92c9-431eb1327b98.gif)

After:
![Peek 2020-05-07 16-50](https://user-images.githubusercontent.com/49662698/81338917-c648d980-9083-11ea-97bc-efc1e0787458.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
