### PR TITLE
Fix filtering by lang with covid and without

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -20,7 +20,7 @@
       = params["language_covid"] || "Select Language"
 
     ul.types-filter
-      = cache(:language_list, expires_in: 1.hour) do
+      = cache(:language_list_covid, expires_in: 1.hour) do
         - Repo.select("DISTINCT language").map(&:language).compact.sort.each do |lang|
           - unless lang.nil?
             li = link_to lang, "#", data: { toggle: "tab", language: lang, query: "language_covid" }


### PR DESCRIPTION
## Description

Simple fix to the homepage language filters that is slightly broken since the introduction of the covid project section.

## Motivation and Context

On the homepage we currently have 2 language filters - one for covid project, other for normal stuff like CodeTriage always had.

Problem is that these 2 filters use slightly different querystring parameters but the view snippet that generates either of them is cached using the same cache key.
This results in both filters working on the same querystring parameter and given the order they exist on the page, right now it is only possible to filter by "language_covid".

## How Has This Been Tested?

By booting the app and clicking around 😭 

I've tried to add a test:

```ruby
  test "has filters for both covid and non-covid projects" do
    visit "/"

    assert page.has_selector?("a[data-query=language_covid]", text: "Ruby")
    assert page.has_selector?("a[data-query=language]", text: "Ruby")
  end
```

but seems like caching is always off on the test env.. which sounds odd given the config.. I need help here...

## Types of changes

Bug fix

## Checklist:

- [x] My code follows the code style of this project.
- [ ] ~My change requires a change to the documentation.~
- [ ] ~I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
