### PR TITLE
update reference to deprecated codebase in covid.rb

### DIFF
--- a/config/initializers/covid.rb
+++ b/config/initializers/covid.rb
@@ -13,7 +13,7 @@ COVID_REPOS = %W{
   CSSEGISandData/COVID-19
   nextstrain/auspice
   nextstrain/augur
-  nextstrain/janus
+  nextstrain/cli
   nextstrain/fauna
   nextstrain/nextstrain.org
   neherlab/covid19_scenarios


### PR DESCRIPTION
nextstrain/janus has been deprecated in favor of nextstrain/cli

## Description
According to the [README in the nextstrain/janus repo](https://github.com/nextstrain/janus#note-about-deprecation), it has been deprecated and superseded by [nextstrain/cli](https://github.com/nextstrain/cli)

## Motivation and Context
Repo was deprecated, directing people to the current repo

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
