### PR TITLE
Fix typo

### DIFF
--- a/app/views/university/picking_a_repo.md.erb
+++ b/app/views/university/picking_a_repo.md.erb
@@ -35,7 +35,7 @@ If you're following our advice, you're planning on subscribing to at least two r
 
 ## Which Repos Exactly should I Pick? Use the Lockfile
 
-Most languages these days have some kind of a lock file, for example, `Gemfile.lock` in Ruby or `Yarn.lock` in Node. These files not only list the dependencies of your application, the list the dependencies of those dependencies.
+Most languages these days have some kind of a lock file, for example, `Gemfile.lock` in Ruby or `Yarn.lock` in Node. These files not only list the dependencies of your application, they also list the dependencies of those dependencies.
 
 Make a list of five dependencies that sound familiar and five that don't seem familiar. For the five you've not heard of before, look them up. What do they do? Do they look interesting?
 


### PR DESCRIPTION
Fixed a typo on [Picking the Right Repo](https://www.codetriage.com/university/picking_a_repo)