### PR TITLE
Remove COVID homepage

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -1,37 +1,12 @@
-/ .hero
-/   h1.hero-title-primary Help out your favorite open source projects and become a better developer while doing it.
-/   = cache(:hero_title_secondary, expires_in: 1.hour) do
-/     h2.hero-title-secondary Pick your favorite repos to receive a different open issue in your inbox every day. Fix the issue and everybody wins. #{number_with_delimiter(User.count, delimiter: ',')} developers are working on #{number_with_delimiter(Repo.count, delimiter: ',')} open source repos using CodeTriage.
-/     h2.hero-title-secondary =link_to "What is CodeTriage?", what_path
-
-/   - unless user_signed_in?
-/       = link_to user_github_omniauth_authorize_path, class: 'button'
-/         | Sign up with GitHub
-
 .hero
-  h1.hero-title-primary Triage Open Source Issues, Squash COVID-19
-  h2.hero-title-secondary There's more interest than ever in contributing to healthcare and emergency response related open-source projects. Here's a few we've found:
+  h1.hero-title-primary Help out your favorite open source projects and become a better developer while doing it.
+  = cache(:hero_title_secondary, expires_in: 1.hour) do
+    h2.hero-title-secondary Pick your favorite repos to receive a different open issue in your inbox every day. Fix the issue and everybody wins. #{number_with_delimiter(User.count, delimiter: ',')} developers are working on #{number_with_delimiter(Repo.count, delimiter: ',')} open source repos using CodeTriage.
+    h2.hero-title-secondary =link_to "What is CodeTriage?", what_path
 
-.repos-list-wrapper
-  .types-filter-wrapper
-    label.types-filter-label Filter list<span> by Language</span>:
-    = render "down"
-    a.types-filter-button
-      = params["language_covid"] || "Select Language"
-
-    ul.types-filter
-      = cache(:language_list_covid, expires_in: 1.hour) do
-        - Repo.select("DISTINCT language").map(&:language).compact.sort.each do |lang|
-          - unless lang.nil?
-            li = link_to lang, "#", data: { toggle: "tab", language: lang, query: "language_covid" }
-
-  section.repo-list-with-pagination
-    = render "repos_with_pagination", repos: @covid_repos
-
-.hero
-  h2.hero-title-secondary To add more COVID-19 related projects please <a href="https://github.com/codetriage/CodeTriage/blob/master/config/initializers/covid.rb#L2">submit a PR</a> to the CodeTriage project.
-  br
-  h2.hero-title-secondary = link_to "What is CodeTriage?", what_path
+  - unless user_signed_in?
+      = link_to user_github_omniauth_authorize_path, class: 'button'
+        | Sign up with GitHub
 
 hr.section-break
 

--- a/test/integration/filtering_language_test.rb
+++ b/test/integration/filtering_language_test.rb
@@ -7,17 +7,9 @@ class FilteringLanguageTest < ActionDispatch::IntegrationTest
     Rails.cache.clear
   end
 
-  test "filtering language in covid projects" do
-    visit "/?language_covid=Ruby"
-
-    assert_equal page.all('.types-filter-button')[0].text, 'Ruby'
-    assert_equal page.all('.types-filter-button')[1].text, 'Select Language'
-  end
-
   test "filtering language in normal projects" do
     visit "/?language=Ruby"
 
-    assert_equal page.all('.types-filter-button')[0].text, 'Select Language'
-    assert_equal page.all('.types-filter-button')[1].text, 'Ruby'
+    assert_equal page.all('.types-filter-button')[0].text, 'Ruby'
   end
 end


### PR DESCRIPTION
The number of COVID related projects Is relatively small and I don't think having them here is particularly driving engagement with those projects.

At the same time, I'm seeing that the overall CodeTriage user growth during the pandemic isn't the same as it was before (eyeballing, I could be wrong). 

I'm still open to exposing these repos somehow, but I think people who don't know what CodeTriage is are getting the mistaken impression it's ONLY covid related, which is not the case.

Let's revert back to the old homepage for now