### PR TITLE
Upgrade Skylight gem to 5.0beta4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,7 @@ gem 'redis-namespace'
 gem 'stackprof'
 gem 'flamegraph'
 gem 'prawn'
-gem 'skylight', '5.0.0.beta2'
+gem 'skylight', '~> 5.0.0.beta4'
 
 gem 'minitest', '5.14.1'
 gem 'sitemap_generator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
       tilt (~> 2.0)
     sitemap_generator (6.1.0)
       builder (~> 3.0)
-    skylight (5.0.0.beta2)
+    skylight (5.0.0.beta4)
       activesupport (>= 5.2.0)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
@@ -508,7 +508,7 @@ DEPENDENCIES
   simplecov
   sinatra (~> 2.0.8)
   sitemap_generator
-  skylight (= 5.0.0.beta2)
+  skylight (~> 5.0.0.beta4)
   slim-rails
   sprockets!
   sprockets-rails


### PR DESCRIPTION
## Description
Upgrade Skylight gem to 5.0.0.beta4

## Related Issue
https://github.com/codetriage/CodeTriage/issues/1406

## Motivation and Context
With 5.0beta4, we can enable the Skylight for Source Locations feature for your account. This feature will allow your contributors to more easily find out exactly where an expensive operation originated without having to scour your code.

## How Has This Been Tested?
Existing tests pass locally.
