### PR TITLE
Fixed typo in Travis-CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## CodeTriage
 
-[![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=master)](http://travis-ci.org/codetriage/codetriage)
+[![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=main)](http://travis-ci.org/codetriage/codetriage)
 [![View performance data on Skylight](https://badges.skylight.io/status/IfSk4kDAh56r.svg)](https://oss.skylight.io/app/applications/IfSk4kDAh56r)
 [![Code Helpers Badge](https://www.codetriage.com/codetriage/codetriage/badges/users.svg)](https://codetriage.com/codetriage/codetriage)
 


### PR DESCRIPTION
I fixed a typo in a link in the README where it says "master" when it should say "main."

## Description
The README contains an image to a Travis-CI badge:

    [![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=master)](http://travis-ci.org/codetriage/codetriage)

I changed this link to say "main" instead of "master," since the default branch in this repo is named main:

    [![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=main)](http://travis-ci.org/codetriage/codetriage)

## Motivation and Context
This fixes the issue of the badge saying "build: error" when it should actually say "build: unknown."

## How Has This Been Tested?
You can see that my changes have fixed the Travis-CI badge by looking at the README in GitHub.

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
