### PR TITLE
The only way to unsubscribe is account deletion

### DIFF
--- a/app/views/users/token_delete.html.slim
+++ b/app/views/users/token_delete.html.slim
@@ -12,7 +12,7 @@ section.subpage-content-wrapper.high
             li= link_to repo.full_name, repo_path(repo)
 
     section.help-triage.content-section
-      | If you have feedback for the project, please
+      | The only thing this app does is send emails. The only way to unsubscribe is account deletion. If you have feedback for the project, please
       = link_to " open up an issue on GitHub", "https://github.com/codetriage/codetriage/issues"
       | .
 


### PR DESCRIPTION
Clarify the point raised in https://github.com/codetriage/CodeTriage/issues/1246

Just changed text on account deletion page.

### Related issues

- https://github.com/codetriage/CodeTriage/issues/883
- https://github.com/codetriage/CodeTriage/issues/710
- https://github.com/codetriage/CodeTriage/issues/409
- https://github.com/codetriage/CodeTriage/issues/144
- https://github.com/codetriage/CodeTriage/issues/135
