### PR TITLE
Moves the "Stop Triaging" button farther up on the page

### DIFF
--- a/app/views/repos/show.html.slim
+++ b/app/views/repos/show.html.slim
@@ -65,6 +65,11 @@ div class="subpage-content-wrapper #{ @repo.weight }"
         section.content-section
           = link_to "Edit this repo", edit_repo_path(@repo), class: 'button full-width-action'
 
+
+    - if @repo_sub
+      section.content-section
+        = link_to repo_subscription_path(@repo_sub), class: 'button stop-triaging full-width-action', method: :delete, data: { confirm: 'Are you sure?' } do
+            | Stop Triaging
     - cache [@repo, "repo_subscribers"] do
       section.avatars.content-section
         h2.content-section-title
@@ -95,7 +100,3 @@ div class="subpage-content-wrapper #{ @repo.weight }"
           .tab-content class=(@docs_pagination ? "is-open" : "")
             - cache_if(!@docs_pagination,  [@repo, "docs"]) do
               = render partial: "docs"
-
-    - if @repo_sub
-      = link_to repo_subscription_path(@repo_sub), class: 'button stop-triaging full-width-action', method: :delete, data: { confirm: 'Are you sure?' } do
-          | Stop Triaging


### PR DESCRIPTION
## Description

This moves the "Stop Triaging" button above the subscribers list and beneath the "Triage Docs!" section.

## Related Issue

https://github.com/codetriage/CodeTriage/issues/1573

## Motivation and Context

I agree with the person who opened the issue.  When I've wanted this function, I don't think to scroll all the way down at first and wished it was easier to access.

## How Has This Been Tested?

I started the app and went to a repo's show page.

## Screenshots (if appropriate):

![Screenshot from 2021-11-13 17-00-19](https://user-images.githubusercontent.com/43712137/141661486-e227a39e-52cd-4595-ad59-cf66cf442999.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
