### PR TITLE
Created api_info_controller_test

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,7 @@ CodeTriage::Application.routes.draw do
     scope '*full_name' do
       constraints full_name: /[-_a-zA-Z0-9]+\/[-_\.a-zA-Z0-9]+/ do
         get   '/badges/:badge_type(.:format)', to: 'badges#show', as: 'badge'
-        get   'info(.:format)',           to: 'api_info#show'
+        get   'info(.:format)',           to: 'api_info#show', :defaults => { :format => 'json' }, as:'api_info'
 
         get   '/',              to: 'repos#show',        as: 'repo'
         patch '/',              to: 'repos#update',      as: nil

--- a/test/functional/api_info_controller_test.rb
+++ b/test/functional/api_info_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class ApiInfoControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @repo = repos(:get_process_mem)
+  end
+  test "show user" do
+    assert get api_info_url({
+      user_name:@repo.user_name, 
+      name:@repo.name,
+      full_name:@repo.full_name,
+      language:@repo.language,
+      created_at:@repo.created_at,
+      updated_at:@repo.updated_at,
+      issues_count:@repo.issues_count,
+      commit_sha:@repo.commit_sha,
+    })
+  end
+
+end


### PR DESCRIPTION
Created an test to api_info_controller, defined json as default response format in routes and added an aliase to api_info#show in routes

## Description
Added in routes 65 line (api_info_controller#show route) :defaults => { :format => 'json' }, as:'api_info' and created an test for this controller

## Related Issue
https://github.com/codetriage/CodeTriage/issues/862


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
