### PR TITLE
new repo view for unauthed user

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -3,7 +3,7 @@
 require File.expand_path("../../../lib/sorted_repo_collection", __FILE__)
 
 class ReposController < RepoBasedController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:create, :edit, :update]
   before_action :default_format
 
   def new

--- a/app/views/repos/new.html.slim
+++ b/app/views/repos/new.html.slim
@@ -6,11 +6,21 @@
     h1.subpage-primary-title Add a new repo to CodeTriage
 
   section.content-section
+  - if user_signed_in?
     h2.content-section-title Add another repo by pasting the full repo URL
-
     = form_tag repos_path, { class: "new_repo", id: "new_repo_from_url" } do
       => text_field_tag :url, @full_name, placeholder: 'full url e.g. "https://github.com/schneems/sextant', class: 'url_field'
       = submit_tag nil, value: "Add Repo", class: 'button full-width-action', id: 'createRepo'
+  - else
+    - if @full_name.blank?
+      p You must be logged in to add a repo to CodeTriage
+    - else
+      p
+        | You must be logged in to add 
+        a href=@full_name 
+          | #{@repo.user_name}/#{@repo.name} 
+        | to CodeTriage.
+    = link_to 'Log in', user_github_omniauth_authorize_path, class: "button full-width-action", method: :post
 
   - if user_signed_in?
     section.content-section

--- a/test/integration/adding_repos_test.rb
+++ b/test/integration/adding_repos_test.rb
@@ -67,4 +67,13 @@ class AddingReposTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? "can't be blank"
   end
+
+  test "add page without login" do
+    # do not login first
+    VCR.use_cassette('blank_repo') do
+      visit "/somerando/project"
+    end
+
+    assert page.has_content? "You must be logged in"
+  end
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In order to prevent the situation described in issue #1499, I changed repo controller to not require the user to be logged in to see the new repo view, and I added conditional rendering in the new repo view to show a message that the user needed to be logged in to add the repo to CodeTriage, and provided a CTA button that begins the Github login flow.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#1499 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is meant to avoid the abrupt authentication error that occurs when an unauthenticated user visits the new repo view.

## How Has This Been Tested?
I tested this locally in a docker container, and ensured that the added test passed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Unauthorized Users:
![Screen Shot 2022-05-29 at 1 55 04 PM](https://user-images.githubusercontent.com/3792749/170884647-0cc3c9fe-bcfa-4dc9-abe5-f8fa7be9b034.png)

After logging in using new button:
![Screen Shot 2022-05-29 at 1 55 33 PM](https://user-images.githubusercontent.com/3792749/170884652-282d9d63-3500-408c-bd35-a5c29e18a00b.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x]  All new and existing tests passed.

cc @bdougie @filiptronicek @0-vortex