### PR TITLE
HTOS muting & switch email signature to a twitter account

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing to CodeTriage
+
 We want to make contributing to this project as straight forward as possible, whether it's:
 
 - Reporting a bug
@@ -7,6 +8,7 @@ We want to make contributing to this project as straight forward as possible, wh
 - Proposing new features
 
 ## Code Changes Happen Through Pull Requests
+
 We use github to host code, to track issues and feature requests, as well as accept pull requests.
 Pull requests are the best way to propose changes to the codebase.
 
@@ -19,9 +21,11 @@ We actively welcome your pull requests:
 6. Issue the pull request using the PULL_REQUEST_TEMPLATE.md
 
 ## Report bugs using Github's issues
+
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/codetriage/codetriage/issues);
 
 ## Write bug reports with detail, background, and sample code
+
 See our ISSUE_TEMPLATE.md when submitting an issue.
 
 **Bug Reports** tend to have:
@@ -79,14 +83,15 @@ $ bin/rake db:create db:schema:load db:seed
 
 If you want your users to sign up with Github, register a [GitHub a new OAuth Application](https://github.com/settings/applications/new). The urls you are asked to provide will be something like this:
 
+- Application name: `CodeTriage local dev`
 - URL: `http://localhost:3000`
 - Callback URL: `http://localhost:3000/users/auth/github/callback`
 
 Then add the credentials to your .env file:
 
 ```shell
-$ echo GITHUB_APP_ID=foo >> .env
-$ echo GITHUB_APP_SECRET=bar >> .env
+$ echo GITHUB_APP_ID=<id from github app> >> .env
+$ echo GITHUB_APP_SECRET=<secret from github app> >> .env
 $ echo PORT=3000 >> .env
 ```
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,6 +69,7 @@ class UsersController < ApplicationController
       :email_frequency,
       :email_time_of_day,
       :skip_issues_with_pr,
+      :htos_contributor_unsubscribe,
       favorite_languages: []
     )
   end

--- a/app/views/layouts/mail_layout.html.erb
+++ b/app/views/layouts/mail_layout.html.erb
@@ -8,6 +8,17 @@
     <div class="logo-wrapper">
       <%= link_to image_tag(asset_url('logo-dark-text.png')), root_url %>
     </div>
+
+  <% if @htos %>
+    <div class="footer-links" style="padding: 0">
+
+      <p>
+        <strong>Don't want to receive free content from my upcoming book <dfn>"How to Open Source"</dfn>?</strong>
+        <%= link_to "Click here to 'mute' these emails", edit_user_url(@user) %>.
+        You'll still receive CodeTriage emails.
+      </p>
+    </div>
+  <% end %>
     <div class="footer-links">
       <% if @user %>
         <%= link_to "Remove Account", token_delete_user_url(@user.account_delete_token) %>

--- a/app/views/layouts/mail_layout.text.erb
+++ b/app/views/layouts/mail_layout.text.erb
@@ -10,5 +10,11 @@
 |________________________________________________</abbr>
 
 <% if @user %>
+<% if @htos %>
+Don't want to receive free content from my upcoming book "How to Open Source"?
+[Click here to "mute" these emails.](<%= edit_user_url(@user) %>%).
+You'll still receive CodeTriage emails.
+
+<% end %>
 [Remove Account](<%= token_delete_user_url(@user.account_delete_token) %>)
 <% end %>

--- a/app/views/user_mailer/daily_docs.md.erb
+++ b/app/views/user_mailer/daily_docs.md.erb
@@ -28,6 +28,5 @@ Hi @<%= @user.github %>,
 
 Go forth and make the world a better place
 
-[Richard Schneeman](https://www.schneems.com)
-
-[Help doctor more docs at codetriage.com](<%= root_url%>)
+[@HowToOpenSource](https://twitter.com/HowToOpenSource)
+[Help doctor more docs at codetriage.com](<%= root_url %>)

--- a/app/views/user_mailer/invalid_token.md.erb
+++ b/app/views/user_mailer/invalid_token.md.erb
@@ -47,5 +47,4 @@ If you intended to revoke access, and don't want to receive any more CodeTriage 
 - - -
 
 Go forth and make the world a better place,
-
-[Richard Schneeman](https://www.schneems.com)
+[@HowToOpenSource](https://twitter.com/HowToOpenSource)

--- a/app/views/user_mailer/poke_inactive.html.erb
+++ b/app/views/user_mailer/poke_inactive.html.erb
@@ -22,5 +22,5 @@ You can also <%= link_to "add your own", new_repo_url %> repo, <%= link_to "brow
 To unsubscribe entirely, <%= link_to "delete your account", user_url(@user) %>, but don't do that, subscribe to project instead. I believe in you.<br /><br />
 
 --<br />
-<%= link_to "Richard Schneeman", "https://www.schneems.com" %>
+<%= link_to "@HowToOpenSource", "https://twitter.com/HowToOpenSource" %>
 </p>

--- a/app/views/user_mailer/poke_inactive.text.erb
+++ b/app/views/user_mailer/poke_inactive.text.erb
@@ -24,4 +24,4 @@ do that, subscribe to an issue above and do some good in the world. I believe
 in you.
 
 --
-@schneems (http://twitter.com/schneems)
+[@HowToOpenSource](https://twitter.com/HowToOpenSource)

--- a/app/views/user_mailer/send_daily_triage.md.erb
+++ b/app/views/user_mailer/send_daily_triage.md.erb
@@ -49,7 +49,4 @@ Hello @<%= @user.github %>,
 ---
 
 Go forth and make the world a better place!
-
-Sincerely,
-
-[Schneems](https://www.schneems.com)
+[@HowToOpenSource](https://twitter.com/HowToOpenSource)

--- a/app/views/user_mailer/send_triage.md.erb
+++ b/app/views/user_mailer/send_triage.md.erb
@@ -62,5 +62,4 @@ Read more about [Fixing Open Source Issues via Triage](https://opensource.com/li
 Go forth and make the world a better place
 
 Sincerely,
-
-[schneems](https://www.schneems.com)
+[HowToOpenSource](https://twitter.com/HowToOpenSource)

--- a/app/views/user_mailer/spam.md.erb
+++ b/app/views/user_mailer/spam.md.erb
@@ -3,5 +3,5 @@ Hi <%= @user.github %>,
 <%= @message.html_safe %>
 
 --
-
 [Richard Schneeman](https://www.schneems.com)
+<%= link_to("Unsubscribe from 'How to Open Source' promotional emails", edit_user_url(@user)) if @htos %>

--- a/app/views/user_mailer/spam.md.erb
+++ b/app/views/user_mailer/spam.md.erb
@@ -3,5 +3,4 @@ Hi <%= @user.github %>,
 <%= @message.html_safe %>
 
 --
-[Richard Schneeman](https://www.schneems.com)
-<%= link_to("Unsubscribe from 'How to Open Source' promotional emails", edit_user_url(@user)) if @htos %>
+[Richard Schneeman](https://www.schneems.com), creator of CodeTriage

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -37,7 +37,11 @@
 
   = f.check_box :skip_issues_with_pr, class: 'checkbox'
   => f.label :skip_issues_with_pr, t("activerecord.attributes.user.skip_issues_with_pr", default: "Skip Pull requests"), class: "label label-info"
-  p By default we send you a combination of issues and pull request, check this box to only get Issues.
+  p By default, we send you a combination of issues and pull request. Check this box to only get Issues.
+
+  = f.check_box :htos_contributor_unsubscribe, class: 'checkbox'
+  => f.label :htos_contributor_unsubscribe, t("activerecord.attributes.user.htos_promo", default: "Mute 'How to Open Source' book content emails"), class: "label label-info"
+  p By default, you will receive promotional emails (e.g. discount codes and free content) for the "How to Open Source: Learn the secrets of successful contributors" book. Check this box to mute those emails.
 
 .form-actions
   => button_tag "Save", class: "button full-width-action"

--- a/db/migrate/20220908011235_add_htos_promo_to_user.rb
+++ b/db/migrate/20220908011235_add_htos_promo_to_user.rb
@@ -1,0 +1,6 @@
+class AddHtosPromoToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :htos_contributor_unsubscribe, :boolean, default: false, null: false
+    add_column :users, :htos_contributor_bought, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_15_123025) do
+ActiveRecord::Schema.define(version: 2022_09_08_011235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -180,6 +180,8 @@ ActiveRecord::Schema.define(version: 2020_11_15_123025) do
     t.integer "raw_streak_count", default: 0
     t.integer "raw_emails_since_click", default: 0
     t.datetime "last_email_at"
+    t.boolean "htos_contributor_unsubscribe", default: false, null: false
+    t.boolean "htos_contributor_bought", default: false, null: false
     t.index ["account_delete_token"], name: "index_users_on_account_delete_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["github"], name: "index_users_on_github", unique: true

--- a/test/mailers/previews/user_preview.rb
+++ b/test/mailers/previews/user_preview.rb
@@ -11,7 +11,7 @@ class UserPreview < ActionMailer::Preview
     user    = User.last
     subject = "Big launch"
     message = "hello world"
-    ::UserMailer.spam(user: user, subject: subject, message: message)
+    ::UserMailer.spam(user: user, subject: subject, message: message, htos_contributor: true)
   end
 
   def send_triage_create


### PR DESCRIPTION
Allows users to mute book promo emails. Also switch email signature to a Twitter account. Having the emails come "from me" isn't really accurate and linking them to my blog isn't terribly useful as I write a bunch about Ruby and non-open source things. I'm instead directing to a dedicated open source Twitter account that can be more focused on open source content.