### PR TITLE
Soft landing for non-post omniauth requests

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,8 +1,26 @@
 - if current_user.blank?
   section.user-logged-out
-    h1= link_to 'Login to view your account', user_github_omniauth_authorize_path, method: :post
+    .subpage-content-wrapper
+      section.subpage-content-header
+        h1.subpage-primary-title You must be logged in to see this content
+        h2.subpage-secondary-title.user-email Please log in
 
-- if current_user && current_user == @user
+      section.user-settings.content-section style="text-align: center"
+        = link_to user_github_omniauth_authorize_path(origin: edit_user_url(@user)), class: 'button', method: :post
+            | Log in
+
+- elsif current_user != @user
+  section.user-logged-out
+    .subpage-content-wrapper
+      section.subpage-content-header
+        h1.subpage-primary-title You may only view your own user account
+        h2.subpage-secondary-title.user-email
+
+      section.user-settings.content-section style="text-align: center"
+        = link_to user_path(current_user), class: 'button'
+            | View my user account
+
+- elsif current_user && current_user == @user
   .subpage-content-wrapper
     section.subpage-content-header
       h1.subpage-primary-title= @user.github
@@ -61,3 +79,5 @@
               = f.check_box :favorite_languages, { multiple: true }, language, nil
               = f.label language, for: "user_favorite_languages_#{language.downcase}"
         p= button_tag "Save Favorite Languages", class: "button full-width-action"
+- else
+  p If you see this something went really wrong. Please open an issue with reproduction steps


### PR DESCRIPTION
Previously any request to `/users/<id>` would trigger a log in flow if you're not logged in. In https://github.com/omniauth/omniauth/pull/1010 (or somewhere around there) omniauth removed the ability to use a GET request to log in at all. Now all login requests must be done via GET. 

This means you cannot redirect to a login endpoint, you must drop the user off somewhere there is a form and they must manually click it to trigger a POST. 

That's what this PR does. If you try to edit or view your user account without being logged in today: it will give you a 404 error page with a cryptic error message.

```
Not found. Authentication passthru.
```

(Which I think omniauth could improve A LOT, FWIW). 

Anywhoo, to move forward I'm replacing the prior `authenticate_user!` before filter with one that checks if the request is a post. If it is, then it will directly authenticate the user. Otherwise we drop them on a "soft" page that tells them they must first login.

It's not perfect, I'm sure there will be edge cases, but it works.
