### PR TITLE
Remove default argument

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -92,7 +92,7 @@ class UserMailer < ActionMailer::Base
   end
 
   # general purpose mailer for sending out admin communications, only use from one off tasks
-  def spam(user:, subject:, message:, htos_contributor: false)
+  def spam(user:, subject:, message:, htos_contributor:)
     return unless set_and_check_user(user)
     @message = message
     @htos = htos_contributor


### PR DESCRIPTION
Prevent emails from being sent with the wrong argument by requiring kwarg presence.

