### PR TITLE
Remove reply-to feature

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -100,15 +100,10 @@ class UserMailer < ActionMailer::Base
     if @htos
       raise AbortDeliveryError if @user.htos_contributor_unsubscribe
       raise AbortDeliveryError if @user.htos_contributor_bought
-
-      reply_to = "get.howtoopensource@gmail.com"
-    else
-      reply_to = "noreply@codetriage.com"
     end
 
     mail(
       to: @user.email,
-      reply_to: reply_to,
       subject: subject
     )
   end


### PR DESCRIPTION
Spam assassin doesn't like when reply-to is from from a freemail provider and doesn't match the `from`. It's hurting deliverability.

People can still get in contact via twitter and other venues.


I'm not sure where the "LONG_HEX_URI" is coming from though.

```
 Content analysis details:   (6.9 points, 5.0 required)
 
  pts rule name              description
 ---- ---------------------- --------------------------------------------------
  1.1 URIBL_GREY             Contains an URL listed in the URIBL greylist
                             [URIs: sendgrid.me]
 -0.0 RCVD_IN_MSPIKE_H2      RBL: Average reputation (+2)
                             [167.89.26.35 listed in wl.mailspike.net]
  0.2 HEADER_FROM_DIFFERENT_DOMAINS From and EnvelopeFrom 2nd level
                             mail domains are different
 -0.0 SPF_PASS               SPF: sender matches SPF record
  0.0 SPF_HELO_NONE          SPF: HELO does not publish an SPF Record
  0.0 HTML_MESSAGE           BODY: HTML included in message
  0.1 DKIM_SIGNED            Message has a DKIM or DK signature, not necessarily
                             valid
 -0.1 DKIM_VALID             Message has at least one valid DKIM or DK signature
  1.6 LONG_HEX_URI           Very long purely hexadecimal URI
  2.5 FREEMAIL_FORGED_REPLYTO Freemail in Reply-To, but not From
  1.5 SENDGRID_REDIR         Redirect URI via Sendgrid
```

