### PR TITLE
Add Gemfile.lock parsing for dependency parser

### DIFF
--- a/lib/dependency_parser/ruby/parse.rb
+++ b/lib/dependency_parser/ruby/parse.rb
@@ -5,26 +5,58 @@ require 'json'
 module DependencyParser
   module Ruby
     class Parse
+      attr_reader :errors
+
       def initialize(content)
         @content = content
+        @errors = []
+        @direct = []
       end
 
       def call
-        deps = Bundler::LockfileParser.new(content)
-        parsed = deps.specs.map do |spec|
-          { repos: [{ name: spec.name }], language: "ruby" }
-        end
-        JSON.pretty_generate(parsed)
+        validate_lockfile!(content)
+        return if error?
+
+        @direct = Bundler::LockfileParser.new(content).specs.map do |spec|
+          fetch_spec(name: spec.name, version: spec.version)
+        end.compact
+      end
+
+      def direct
+        { repos: @direct, language: "ruby" }
+      end
+
+      def success?
+        errors.empty?
+      end
+
+      def error?
+        errors.any?
       end
 
       private
 
       attr_reader :content
 
-      def self.valid_gemfile?(content)
-        Bundler::LockfileParser.new(content).specs.any?
+      def validate_lockfile!(content)
+        @errors << 'No specs found' unless Bundler::LockfileParser.new(content).specs.any?
+      end
+
+      def fetch_spec(name:, version: nil)
+        full_spec = fetcher.fetch_spec([name, version])
+        { name: full_spec.name, url: extract_url(full_spec), description: full_spec.description }
       rescue
-        false
+        @errors << "Invalid spec #{name}"
+        nil
+      end
+
+      def extract_url(full_spec)
+        url = full_spec.metadata["source_code_uri"] || full_spec.homepage
+        url if url.include? "https://github.com/"
+      end
+
+      def fetcher
+        @fetcher ||= Bundler::Fetcher.new(Bundler::Source::Rubygems::Remote.new('https://rubygems.org'))
       end
     end
   end

--- a/lib/dependency_parser/ruby/parse.rb
+++ b/lib/dependency_parser/ruby/parse.rb
@@ -29,6 +29,3 @@ module DependencyParser
     end
   end
 end
-
-content = ARGF.read
-puts DependencyParser::Ruby::Parse.new(content).call if DependencyParser::Ruby::Parse.valid_gemfile?(content)

--- a/lib/dependency_parser/ruby/parse.rb
+++ b/lib/dependency_parser/ruby/parse.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'bundler'
+require 'json'
+
+module DependencyParser
+  module Ruby
+    class Parse
+      def initialize(content)
+        @content = content
+      end
+
+      def call
+        deps = Bundler::LockfileParser.new(content)
+        parsed = deps.specs.map do |spec|
+          { repos: [{ name: spec.name }], language: "ruby" }
+        end
+        JSON.pretty_generate(parsed)
+      end
+
+      private
+
+      attr_reader :content
+
+      def self.valid_gemfile?(content)
+        Bundler::LockfileParser.new(content).specs.any?
+      rescue
+        false
+      end
+    end
+  end
+end
+
+content = ARGF.read
+puts DependencyParser::Ruby::Parse.new(content).call if DependencyParser::Ruby::Parse.valid_gemfile?(content)

--- a/test/dependency_parsers/ruby_parser_test.rb
+++ b/test/dependency_parsers/ruby_parser_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../../lib/dependency_parser/ruby/parse'
+
+class UserMailerTest < ActiveSupport::TestCase
+  test "returns nothing on invalid Gemfile.lock" do
+    deps = DependencyParser::Ruby::Parse.new("invalid").call
+    assert_equal [], JSON.parse(deps)
+  end
+
+  test "returns the list of gems for a small Gemfle" do
+    gemfile_lock = <<-LOCKFILE
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actioncable
+
+RUBY VERSION
+   ruby 3.0.4p208
+
+BUNDLED WITH
+   2.3.21
+
+LOCKFILE
+
+    deps = DependencyParser::Ruby::Parse.new(gemfile_lock).call
+    assert_equal [{ "repos" => [{ "name" => "actioncable" }], "language" => "ruby" }], JSON.parse(deps)
+  end
+end

--- a/test/dependency_parsers/ruby_parser_test.rb
+++ b/test/dependency_parsers/ruby_parser_test.rb
@@ -3,38 +3,55 @@
 require 'test_helper'
 require_relative '../../lib/dependency_parser/ruby/parse'
 
-class UserMailerTest < ActiveSupport::TestCase
+class RubyParserTest < ActiveSupport::TestCase
   test "returns nothing on invalid Gemfile.lock" do
-    deps = DependencyParser::Ruby::Parse.new("invalid").call
-    assert_equal [], JSON.parse(deps)
+    parser = DependencyParser::Ruby::Parse.new("invalid")
+    parser.call
+    refute parser.success?
+    assert_equal({ repos: [], language: "ruby" }, parser.direct)
   end
 
   test "returns the list of gems for a small Gemfle" do
-    gemfile_lock = <<-LOCKFILE
-GEM
-  remote: https://rubygems.org/
-  specs:
-    actioncable (6.1.4.1)
-      actionpack (= 6.1.4.1)
-      activesupport (= 6.1.4.1)
-      nio4r (~> 2.0)
-      websocket-driver (>= 0.6.1)
+    gemfile_lock = <<~LOCKFILE
+      GEM
+        remote: https://rubygems.org/
+        specs:
+          solid_use_case (2.2.0)
+            actionpack (= 6.1.4.1)
+            activesupport (= 6.1.4.1)
+            nio4r (~> 2.0)
+            websocket-driver (>= 0.6.1)
 
-PLATFORMS
-  ruby
+      PLATFORMS
+        ruby
 
-DEPENDENCIES
-  actioncable
+      DEPENDENCIES
+        actioncable
 
-RUBY VERSION
-   ruby 3.0.4p208
+      RUBY VERSION
+         ruby 3.0.4p208
 
-BUNDLED WITH
-   2.3.21
+      BUNDLED WITH
+         2.3.21
 
-LOCKFILE
+      LOCKFILE
 
-    deps = DependencyParser::Ruby::Parse.new(gemfile_lock).call
-    assert_equal [{ "repos" => [{ "name" => "actioncable" }], "language" => "ruby" }], JSON.parse(deps)
+    parser = DependencyParser::Ruby::Parse.new(gemfile_lock)
+    VCR.use_cassette("dependency_parser/rubygems") do
+      parser.call
+    end
+
+    gem_data = {
+      repos:
+        [{
+          name: "solid_use_case",
+          url: "https://github.com/mindeavor/solid_use_case",
+          description: "Create use cases the way they were meant to be. Easily verify inputs at each step and seamlessly fail with custom error data and convenient pattern matching."
+        }],
+      language: "ruby"
+    }
+
+    assert parser.success?
+    assert_equal gem_data, parser.direct
   end
 end

--- a/test/vcr_cassettes/dependency_parser/rubygems.yml
+++ b/test/vcr_cassettes/dependency_parser/rubygems.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://rubygems.org/quick/Marshal.4.8/solid_use_case-2.2.0.gemspec.rz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - bundler/2.3.9 rubygems/3.2.22 ruby/3.0.2 (arm64-apple-darwin21) command/test/dependency_parsers/ruby_parser_test.rb:13
+        options/build.phashion,gem.changelog,gem.ci,gem.linter,gem.test,gemfile,https://rubygems.pkg.github.com/ygt/
+        7cda2dac900b8423
+      X-Gemfile-Source:
+      - https://rubygems.org
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '592'
+      X-Amz-Id-2:
+      - 0u4/8xPTWA1CSBolnInrTN2/6IE8DMfo1GHKNR8G6foJ7RLkvjNC4kGGjpnqkgqfTINlW36ZgVc=
+      X-Amz-Request-Id:
+      - N2TE9JHWB6SS5C23
+      X-Amz-Replication-Status:
+      - COMPLETED
+      Last-Modified:
+      - Thu, 15 Nov 2018 21:09:40 GMT
+      Etag:
+      - '"fd2cb96eb8a580cf8c814eebf6f33774"'
+      Cache-Control:
+      - max-age=31536000
+      X-Amz-Version-Id:
+      - if3V8D36kQXmr15lP1gHamlXJOcPhCzY
+      Via:
+      - 1.1 varnish, 1.1 varnish
+      Content-Type:
+      - application/octet-stream
+      X-Backend:
+      - F_S3 52.92.132.122:443, fastlyshield--shield_ssl_cache_sea4479_SEA 199.27.78.79:443
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Wed, 05 Oct 2022 20:29:29 GMT
+      Age:
+      - '1290391'
+      X-Served-By:
+      - cache-sea4479-SEA, cache-fra19161-FRA
+      X-Cache:
+      - HIT, HIT
+      X-Cache-Hits:
+      - 9, 1
+      X-Timer:
+      - S1665001770.681589,VS0,VE1
+      Server:
+      - RubyGems.org
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eJyNU8Fu00AQDShyYzcRSQGBEKCRjxVykhZxWIsqqDSVD0gIEi45RGt7kqxq75rddYKLxJ/wAfwFn8KnsHZoCUqjYh/s3X375s3Mm3ojJ4/OMSXkY4YRm7GIaib43YN6vTF5HLj7R94rr39sEetsxOzAva9EwuJprnAaUYWWXxuNSaci+IRSmasTK3CdI+/I65WHQU7sEUux9evHs58181jEvhQcA7cxHp0axDBw37+BWYJfWJggjBWeGl7IqNYoOegF1bAS8kLB4YrpxSEUIpfVziwRqxfAhQY6p4wrDUx7a0EPK0Ef8HPOJKbI9cQy717g7n07qRC+Vcps/BE59u1rwMnrDYC1zsG1ZR4W5e/EFuRBRf4WM+Qx8qhwiDPgNDUpHcRoRKeMM6VZVOJJZyD/qtiM848Qp2eqXMUyXLrIkDRlzrWpG2kPMokSEzRVGZIng+W6ytMNWvUfvMJ3HH8/cJthzuMEZbnnN3debPS94wrSIu0Yl5iIrIzk3xv67VsvXcWyJb3A7UA3VNhv+Z0t7htwV8yOVMatt+RgrNt/6fV38u8C98r10zlLQpQ6nFN5SQfzlLLEi0RamcCcN8/X52t/3Pl+KpFqBDMXUM6FMsZFWNGi/BawMh2EFCnXoAWE6MEZVSwpwHSTzQpgPMu1AmN1pNEClMYMKI9BIU0TVMogZ0YAlBMAUa60SAGlFBJiqmkFjQRfImemSdezk1IdLRife2uRvYXWmSLd7tyw5GGZTdd4NUa6FLK7PdejwfOqq++CUbn8WvsNWwIjBg==
+  recorded_at: Wed, 05 Oct 2022 20:29:29 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Dependency parsing for #1686

Uses Bundler gem for parsing, parses only name for now, we should probably extract URL for repos.

## Description

## Related Issue
- #1686 Gemfile.lock, more languages to come, stay tuned ;) 

## Motivation and Context
An initial stub to get the dependency parsing running

## How Has This Been Tested?
- invalid file + a tiny Gemfile.lock, might need more testing

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
