### PR TITLE
Upgrade VCR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.6.5
+  TargetRubyVersion: 3.1.2
   DisplayCopNames: true
   StyleGuideCopsOnly: false
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,7 +450,7 @@ GEM
       activemodel
       mail (>= 2.6.1)
       simpleidn
-    vcr (6.0.0)
+    vcr (6.1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)


### PR DESCRIPTION
Previously we were getting this warning/error:

```
$ be rake test
[Scout] [10/08/22 19:32:44 -0500 rschnee-ltm4wff.internal.salesforce.com (18670)] INFO : Failed loading configuration file (/Users/rschneeman/Documents/projects/codetriage/config/scout_apm.yml): Unknown alias: defaults. ScoutAPM will continue starting with configuration from ENV and defaults
Run options: --seed 11077

# Running:

................................................................................................................................................................................

Finished in 9.171450s, 20.4984 runs/s, 38.9251 assertions/s.
188 runs, 357 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Minitest to /Users/rschneeman/Documents/projects/codetriage/coverage. 1066 / 1515 LOC (70.36%) covered.
/Users/rschneeman/.gem/ruby/3.1.2/bin/bundle: warning: Exception in finalizer #<Proc:0x00000001178c4b60 /Users/rschneeman/.gem/ruby/3.1.2/gems/vcr-6.0.0/lib/vcr/library_hooks/webmock.rb:36 (lambda)>
/Users/rschneeman/.gem/ruby/3.1.2/gems/vcr-6.0.0/lib/vcr/library_hooks/webmock.rb:36:in `block in global_hook_disabled_requests': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

