### PR TITLE
Fix tests broken by prior commit

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,8 @@ OmniAuth.config.add_mock(
     },
     email: "mockstar@example.com",
     info: {
-      nickname: 'mockstar'
+      nickname: 'mockstar',
+      email: "mockstar@example.com"
     },
     extra: {
       raw_info: {


### PR DESCRIPTION
Tests were failing due to missing VCR stub. This fixes by providing information so we don't try to hit GitHub's API.
