### PR TITLE
Adds routine to keep repo up to date

### DIFF
--- a/app/models/github_fetcher/resource.rb
+++ b/app/models/github_fetcher/resource.rb
@@ -56,6 +56,10 @@ module GithubFetcher
       false
     end
 
+    def not_found?
+      status == 404 ? true : false
+    end
+
     def bad_token?
       if status == 401 && response.body.match?(/Bad credentials/)
         @error = @error_message = "Bad credentials"

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -192,12 +192,26 @@ class Repo < ActiveRecord::Base
   end
 
   def update_from_github
-    json = fetcher.as_json
-    self.update(
-      language: json.fetch('language', language),
-      description: json.fetch('description', description)&.first(255),
-      stars_count: json.fetch('stargazers_count', stars_count)
-    )
+    if fetcher.not_found?
+      self.update!(removed_from_github: true)
+    elsif fetcher.success?
+      repo_full_name = fetcher_json.fetch('full_name', full_name)
+
+      if repo_full_name != full_name && self.class.exists_with_name?(repo_full_name)
+        # TODO: Add deduplication step
+        return
+      end
+
+      repo_user_name, repo_name = repo_full_name.split("/")
+      self.update!(
+        name: repo_name,
+        user_name: repo_user_name,
+        language: fetcher_json.fetch('language', language),
+        description: fetcher_json.fetch('description', description)&.first(255),
+        full_name: repo_full_name,
+        removed_from_github: false
+      )
+    end
   end
 
   def repo_path

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -37,7 +37,7 @@ class Repo < ActiveRecord::Base
   end
 
   def fetcher_json
-    fetcher.as_json
+    @fetcher_json ||= fetcher.as_json
   end
 
   def issues_fetcher

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -209,7 +209,8 @@ class Repo < ActiveRecord::Base
         language: fetcher_json.fetch('language', language),
         description: fetcher_json.fetch('description', description)&.first(255),
         full_name: repo_full_name,
-        removed_from_github: false
+        removed_from_github: false,
+        archived: fetcher_json.fetch('archived', archived)
       )
     end
   end

--- a/db/migrate/20221013212959_add_archived_column_to_repo.rb
+++ b/db/migrate/20221013212959_add_archived_column_to_repo.rb
@@ -1,0 +1,6 @@
+class AddArchivedColumnToRepo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :repos, :archived, :boolean, default: false
+    add_index :repos, :archived
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_10_011048) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_13_212959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -155,6 +155,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_10_011048) do
     t.integer "subscribers_count", default: 0
     t.integer "docs_subscriber_count", default: 0
     t.boolean "removed_from_github", default: false
+    t.boolean "archived", default: false
+    t.index ["archived"], name: "index_repos_on_archived"
     t.index ["full_name"], name: "index_repos_on_full_name"
     t.index ["issues_count"], name: "index_repos_on_issues_count"
     t.index ["language"], name: "index_repos_on_language"

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -38,17 +38,12 @@ namespace :schedule do
     return GithubFetcher::Repo.new(user_name: "rails", name: "rails").success?
   end
 
-  desc "Checks if repos have been deleted on GitHub"
-  task mark_removed_repos: :environment do
+  desc "Update repos information"
+  task update_repos: :environment do
     raise "GITHUB API APPEARS TO BE DOWN" unless github_api_up?
 
-    Repo.select(:id, :user_name, :name).find_each(batch_size: 100) do |repo|
-      fetcher = GithubFetcher::Repo.new(user_name: repo.user_name, name: repo.name)
-      fetcher.call(retry_on_bad_token: 5)
-
-      if fetcher.response.status == 404
-        repo.update!(removed_from_github: true)
-      end
+    Repo.find_each(batch_size: 100) do |repo|
+      repo.update_repo_info!
     end
   end
 

--- a/test/jobs/update_repo_info_job_test.rb
+++ b/test/jobs/update_repo_info_job_test.rb
@@ -2,8 +2,70 @@
 
 require 'test_helper'
 
+# frozen_string_literal: true
+
+require 'test_helper'
 class UpdateRepoInfoJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'repo deleted or made private' do
+    GithubFetcher::Resource.any_instance.stubs(:status).returns(404)
+    @repo = repos(:node)
+    assert_changes -> {
+      [
+        @repo.reload.removed_from_github,
+      ]
+    } do
+      UpdateRepoInfoJob.perform_now(@repo)
+    end
+    assert @repo.reload.removed_from_github
+  end
+
+  test 'repo with information updated' do
+    GithubFetcher::Resource.any_instance.stubs(:status).returns(200)
+    GithubFetcher::Resource.any_instance.stubs(:as_json).returns(
+      {
+        'full_name' => 'test_owner/test_repo',
+        'language' => 'test_language',
+        'description' => 'test_description'
+      }
+    )
+    @repo = repos(:node)
+    assert_changes -> {
+      [
+        @repo.reload.full_name,
+        @repo.reload.name,
+        @repo.reload.user_name,
+        @repo.reload.language,
+        @repo.reload.description,
+      ]
+    } do
+      UpdateRepoInfoJob.perform_now(@repo)
+    end
+    assert_equal false, @repo.reload.removed_from_github
+    assert_equal 'test_owner/test_repo', @repo.reload.full_name
+    assert_equal 'test_repo', @repo.reload.name
+    assert_equal 'test_owner', @repo.reload.user_name
+    assert_equal 'test_language', @repo.reload.language
+    assert_equal 'test_description', @repo.reload.description
+  end
+
+  test 'repo rename conflict' do
+    GithubFetcher::Resource.any_instance.stubs(:status).returns(200)
+    GithubFetcher::Resource.any_instance.stubs(:as_json).returns(
+      {
+        'full_name' => 'sinatra/sinatra',
+      }
+    )
+    @repo = repos(:node)
+    assert_no_changes -> {
+      [
+        @repo.reload.full_name,
+        @repo.reload.name,
+        @repo.reload.user_name,
+        @repo.reload.language,
+        @repo.reload.description,
+      ]
+    } do
+      UpdateRepoInfoJob.perform_now(@repo)
+    end
+  end
 end

--- a/test/jobs/update_repo_info_job_test.rb
+++ b/test/jobs/update_repo_info_job_test.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-
-# frozen_string_literal: true
-
-require 'test_helper'
 class UpdateRepoInfoJobTest < ActiveJob::TestCase
   test 'repo deleted or made private' do
     GithubFetcher::Resource.any_instance.stubs(:status).returns(404)

--- a/test/jobs/update_repo_info_job_test.rb
+++ b/test/jobs/update_repo_info_job_test.rb
@@ -26,7 +26,8 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
       {
         'full_name' => 'test_owner/test_repo',
         'language' => 'test_language',
-        'description' => 'test_description'
+        'description' => 'test_description',
+        'archived' => true
       }
     )
     repo = repos(:node)
@@ -37,6 +38,7 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
         repo.user_name,
         repo.language,
         repo.description,
+        repo.archived
       ]
     } do
       UpdateRepoInfoJob.perform_now(repo)
@@ -48,6 +50,7 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
     assert_equal 'test_owner', repo.user_name
     assert_equal 'test_language', repo.language
     assert_equal 'test_description', repo.description
+    assert_equal true, repo.archived
   end
 
   test 'repo rename conflict' do
@@ -65,6 +68,7 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
         repo.user_name,
         repo.language,
         repo.description,
+        repo.archived
       ]
     } do
       UpdateRepoInfoJob.perform_now(repo)

--- a/test/jobs/update_repo_info_job_test.rb
+++ b/test/jobs/update_repo_info_job_test.rb
@@ -8,15 +8,16 @@ require 'test_helper'
 class UpdateRepoInfoJobTest < ActiveJob::TestCase
   test 'repo deleted or made private' do
     GithubFetcher::Resource.any_instance.stubs(:status).returns(404)
-    @repo = repos(:node)
+    repo = repos(:node)
     assert_changes -> {
       [
-        @repo.reload.removed_from_github,
+        repo.removed_from_github,
       ]
     } do
-      UpdateRepoInfoJob.perform_now(@repo)
+      UpdateRepoInfoJob.perform_now(repo)
+      repo.reload
     end
-    assert @repo.reload.removed_from_github
+    assert repo.removed_from_github
   end
 
   test 'repo with information updated' do
@@ -28,24 +29,25 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
         'description' => 'test_description'
       }
     )
-    @repo = repos(:node)
+    repo = repos(:node)
     assert_changes -> {
       [
-        @repo.reload.full_name,
-        @repo.reload.name,
-        @repo.reload.user_name,
-        @repo.reload.language,
-        @repo.reload.description,
+        repo.full_name,
+        repo.name,
+        repo.user_name,
+        repo.language,
+        repo.description,
       ]
     } do
-      UpdateRepoInfoJob.perform_now(@repo)
+      UpdateRepoInfoJob.perform_now(repo)
+      repo.reload
     end
-    assert_equal false, @repo.reload.removed_from_github
-    assert_equal 'test_owner/test_repo', @repo.reload.full_name
-    assert_equal 'test_repo', @repo.reload.name
-    assert_equal 'test_owner', @repo.reload.user_name
-    assert_equal 'test_language', @repo.reload.language
-    assert_equal 'test_description', @repo.reload.description
+    assert_equal false, repo.removed_from_github
+    assert_equal 'test_owner/test_repo', repo.full_name
+    assert_equal 'test_repo', repo.name
+    assert_equal 'test_owner', repo.user_name
+    assert_equal 'test_language', repo.language
+    assert_equal 'test_description', repo.description
   end
 
   test 'repo rename conflict' do
@@ -55,17 +57,18 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
         'full_name' => 'sinatra/sinatra',
       }
     )
-    @repo = repos(:node)
+    repo = repos(:node)
     assert_no_changes -> {
       [
-        @repo.reload.full_name,
-        @repo.reload.name,
-        @repo.reload.user_name,
-        @repo.reload.language,
-        @repo.reload.description,
+        repo.full_name,
+        repo.name,
+        repo.user_name,
+        repo.language,
+        repo.description,
       ]
     } do
-      UpdateRepoInfoJob.perform_now(@repo)
+      UpdateRepoInfoJob.perform_now(repo)
+      repo.reload
     end
   end
 end

--- a/test/unit/github_fetcher/resource_test.rb
+++ b/test/unit/github_fetcher/resource_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class GithubFetcher::ResourceTest < ActiveSupport::TestCase
+  def status_validation(mocked_status, method, expected_response)
+    GithubFetcher::Resource.any_instance.stubs(:status).returns(mocked_status)
+    resource = GithubFetcher::Resource.new({})
+    assert_equal expected_response, resource.send(method)
+  end
+
+  test '#not_found? is true on 404 status responses' do
+    status_validation(404, :not_found?, true)
+  end
+
+  test '#not_found? is false on non 404 status responses' do
+    [200, 201, 204, 400, 403, 500, 502].each { |status| status_validation(status, :not_found?, false) }
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds routine to keep repos records up to date.
Column added: `archived`
Columns monitored: `name`, `user_name `, `full_name`, `description`, `removed_from_github`, `archived`, `language`

⚠️ Replaces periodic task `mark_removed_repos ` with `update_repos`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Partially deals with #1704

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Discussed on the issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Old testes passed
- Added tests to new functionality

(+ Rubocop passed)

## Screenshots (if appropriate):
--

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
