### PR TITLE
Update default branch name from `master` to `main` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull requests are the best way to propose changes to the codebase.
 
 We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I guess default branch has been changed from `master` to `main`, right? 
Currently, default is `main` and target branch of each PR is also `main`.
So I updated the document.

<!--- Describe your changes in detail -->

## Related Issue
no issue, is it right?
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

`master` branch has not deleted today. (BTW, It sounds good to delete master branch if maintainer is OK)
If newbie or creator or who follow the CONTRIBUTING.md faithfully might make a PR to master branch.
I can prevent it by updating document.

<!--- Why is this change required? What problem does it solve? -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
