### PR TITLE
Replaced the defunct Travis CI badge with the GitHub Workflows CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## CodeTriage
 
-[![Build Status](https://secure.travis-ci.org/codetriage/codetriage.svg?branch=main)](http://travis-ci.org/codetriage/codetriage)
+[![Main](https://github.com/codetriage/CodeTriage/actions/workflows/main.yml/badge.svg)](https://github.com/codetriage/CodeTriage/actions/workflows/main.yml)
 [![View performance data on Skylight](https://badges.skylight.io/status/IfSk4kDAh56r.svg)](https://oss.skylight.io/app/applications/IfSk4kDAh56r)
 [![Code Helpers Badge](https://www.codetriage.com/codetriage/codetriage/badges/users.svg)](https://codetriage.com/codetriage/codetriage)
 


### PR DESCRIPTION
## Description
This pull request replaces the defunct Travis CI badge with the GitHub Workflows CI badge.  It's just one minor change in the README.md file.

## Related Issue
This pull request addresses Issue #1769 .

