### PR TITLE
Reorganize gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,6 @@ gem 'redis-namespace'
 # Database
 gem 'pg'
 
-# Documentation
-gem 'yard', '~> 0.9.28'
-
 # Email
 gem 'mail', require: ['mail', 'mail/utilities', 'mail/parsers'] # parsers is used by `valid_email` and may be causing https://github.com/mikel/mail/issues/912#issuecomment-170121429
 gem 'premailer-rails'
@@ -106,9 +103,6 @@ gem 'sitemap_generator'
 # Storage
 gem 'aws-sdk-s3'
 
-# Tests
-gem 'minitest'
-
 # Utilities
 gem 'rake'
 gem 'rrrretry'
@@ -118,11 +112,13 @@ group :development do
   gem 'listen'
   gem 'memory_profiler'
   gem 'web-console'
+  gem 'yard', '~> 0.9.28'
 end
 
 group :test do
   gem 'capybara'
   gem 'launchy' # Not essential but helpful for save_and_open_page
+  gem 'minitest'
   gem 'mocha', require: false
   gem 'rails-controller-testing'
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,62 +13,122 @@ git_source :github do |name|
   "https://github.com/#{name}.git"
 end
 
-gem 'mime-types', require: 'mime/types/columnar'
-
-# Gems required in all environments
+# Core
 if ENV["RAILS_MASTER"] == '1'
   gem 'rails', git: 'https://github.com/rails/rails.git'
 else
   gem 'rails', '7.0.4'
 end
 
-gem 'bluecloth'
-gem 'dalli'
-gem 'devise'
+# API & Networking
 gem 'git_hub_bub'
-gem 'jquery-rails'
-gem 'local_time'
-gem 'maildown'
-gem 'omniauth'
-gem 'omniauth-rails_csrf_protection'
-gem 'omniauth-github'
-gem 'pg'
-gem 'puma'
-gem 'rack-timeout'
-gem 'rrrretry'
-gem 'valid_email'
-gem 'wicked'
-gem 'will_paginate'
-# gem 'sass-rails', '6.0.0.beta1'
-gem 'sassc'
-gem 'sassc-rails'
 
+# Application server & middleware
+gem 'puma'
+gem 'puma_worker_killer'
+gem 'rack-timeout'
+gem 'rack-canonical-host'
+
+# Assets
 gem 'autoprefixer-rails'
+gem 'babel-transpiler'
 gem 'bourbon'
 gem 'coffee-rails', '~> 5.0.0'
 gem 'neat', '~> 1.7'
 gem 'normalize-rails'
+gem 'sassc'
+gem 'sassc-rails'
 gem 'slim-rails'
+gem 'sprockets'
+gem 'sprockets-rails'
 gem 'uglifier', '>= 1.0.3'
+
+# Authentication & Authorization
+gem 'devise'
+gem 'omniauth'
+gem 'omniauth-rails_csrf_protection'
+gem 'omniauth-github'
+
+# Backgroud jobs
+gem 'sidekiq'
+gem 'sinatra'
+
+# Caching
+gem 'dalli'
+gem 'redis-namespace'
+
+# Database
+gem 'pg'
+
+# Documentation
+gem 'yard', '~> 0.9.28'
+
+# Email
+gem 'mail', require: ['mail', 'mail/utilities', 'mail/parsers'] # parsers is used by `valid_email` and may be causing https://github.com/mikel/mail/issues/912#issuecomment-170121429
+gem 'premailer-rails'
+gem 'valid_email'
+
+# File Handling & Data Processing
+gem 'mime-types', require: 'mime/types/columnar'
+
+# JavaScript
+gem 'jquery-rails'
 gem 'render_async'
+
+# JSON
+gem 'oj'
+
+# Views
+gem 'bluecloth'
+gem 'local_time'
+gem 'maildown'
+gem 'wicked'
+
+# Pagination
+gem 'will_paginate'
+
+# Performance & Monitoring
+gem 'bootsnap', require: false
+gem 'flamegraph'
+gem 'matrix'
+gem 'prawn'
+gem 'rack-mini-profiler'
+gem 'rails-autoscale-web'
+gem 'rbtrace'
+gem 'sentry-raven'
+gem 'scout_apm'
+gem 'skylight'
+gem 'stackprof'
+
+# SEO & Sitemaps
+gem 'sitemap_generator'
+
+# Storage
+gem 'aws-sdk-s3'
+
+# Tests
+gem 'minitest'
+
+# Utilities
+gem 'rake'
+gem 'rrrretry'
 
 group :development do
   gem 'foreman'
   gem 'listen'
-  gem 'web-console'
   gem 'memory_profiler'
+  gem 'web-console'
 end
 
 group :test do
   gem 'capybara'
-  # Not essential but helpful for save_and_open_page
-  gem 'launchy'
+  gem 'launchy' # Not essential but helpful for save_and_open_page
   gem 'mocha', require: false
   gem 'rails-controller-testing'
   gem 'simplecov', require: false
+  gem 'test-prof'
   gem 'vcr'
   gem 'webmock'
-  gem 'test-prof'
 end
 
 group :development, :test do
@@ -79,42 +139,3 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-performance'
 end
-
-gem 'rack-mini-profiler'
-
-gem 'sidekiq'
-gem 'sinatra'
-
-gem 'aws-sdk-s3'
-
-gem 'mail', require: ['mail', 'mail/utilities', 'mail/parsers'] # parsers is used by `valid_email` and may be causing https://github.com/mikel/mail/issues/912#issuecomment-170121429
-
-gem 'sprockets'
-gem 'sprockets-rails'
-
-gem 'babel-transpiler'
-
-gem 'scout_apm'
-gem 'yard', '~> 0.9.28'
-
-gem 'oj'
-gem 'rack-canonical-host'
-gem 'sentry-raven'
-
-gem 'bootsnap', require: false
-gem 'rbtrace'
-gem 'redis-namespace'
-gem 'stackprof'
-gem 'flamegraph'
-gem 'prawn'
-gem 'skylight'
-gem 'matrix'
-
-gem 'minitest'
-gem 'sitemap_generator'
-gem 'premailer-rails'
-
-# gem 'barnes'
-gem 'puma_worker_killer'
-gem 'rake'
-gem 'rails-autoscale-web'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     bluecloth (2.2.0)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
-    bourbon (7.2.0)
+    bourbon (7.3.0)
       thor (~> 1.0)
     builder (3.2.4)
     capybara (3.37.1)


### PR DESCRIPTION
This pull request addresses issue https://github.com/codetriage/CodeTriage/issues/1782 by reorganizing and categorizing the gems in the Gemfile to improve understanding and maintainability. The changes ensure that related gems are grouped together, making it easier to identify their purpose and the application components they relate to. I have also moved certain gems, such as minitest and yard, to more specific environment groups for better dependency management.

Please review the changes and let me know if any adjustments are needed. Thank you for considering my contribution.