### PR TITLE
Ignore self signed Redis certs

### DIFF
--- a/app/models/random/cached_id_query.rb
+++ b/app/models/random/cached_id_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Provides an actual random result exactly as expected
 # but it's cached for a period of time.
 #

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,11 +2,19 @@
 
 unless Rails.env.production?
   Sidekiq.configure_server do |config|
-    config.redis = { url: ENV["REDIS_URL"], namespace: "codetriage-sidekiq" }
+    config.redis = {
+      url: ENV["REDIS_URL"],
+      namespace: "codetriage-sidekiq",
+      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    }
   end
 
   Sidekiq.configure_client do |config|
-    config.redis = { url: ENV["REDIS_URL"], namespace: "codetriage-sidekiq" }
+    config.redis = {
+      url: ENV["REDIS_URL"],
+      namespace: "codetriage-sidekiq",
+      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    }
   end
 end
 


### PR DESCRIPTION
Heroku upgraded Redis instances to Redis 7. Premium redis instances now enforce TLS (SSL), which is a good thing, however the certs are self-signed which causes a validation error.

The documented fix is to disable the validation. https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-from-sidekiq

Close #1787

