### PR TITLE
Ignore self signed Redis certs in prod

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
-unless Rails.env.production?
-  Sidekiq.configure_server do |config|
-    config.redis = {
-      url: ENV["REDIS_URL"],
-      namespace: "codetriage-sidekiq",
-      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-    }
-  end
+sidekiq_config = {
+  url: ENV["REDIS_URL"],
+  ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+}
 
-  Sidekiq.configure_client do |config|
-    config.redis = {
-      url: ENV["REDIS_URL"],
-      namespace: "codetriage-sidekiq",
-      ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-    }
-  end
+unless Rails.env.production?
+  sidekiq_config[:namespace] = "codetriage-sidekiq"
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = sidekiq_config
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = sidekiq_config
 end
 
 if Sidekiq.server?


### PR DESCRIPTION
The prior commit only applied SSL verification logic to all environments except production. This fix applies to production.


Close #1787
