### PR TITLE
Deduplicate transferred / moved repos

### DIFF
--- a/test/jobs/update_repo_info_job_test.rb
+++ b/test/jobs/update_repo_info_job_test.rb
@@ -56,19 +56,13 @@ class UpdateRepoInfoJobTest < ActiveJob::TestCase
         "full_name" => "sinatra/sinatra"
       }
     )
-    repo = repos(:node)
-    assert_no_changes -> {
-      [
-        repo.full_name,
-        repo.name,
-        repo.user_name,
-        repo.language,
-        repo.description,
-        repo.archived
-      ]
-    } do
+    repo = repos(:rails_rails)
+    sinatra = repos(:sinatra_sinatra)
+
+    assert_difference "Repo.count", -1 do
       UpdateRepoInfoJob.perform_now(repo)
-      repo.reload
     end
+
+    assert_equal 2, sinatra.subscribers.count
   end
 end


### PR DESCRIPTION
## Description

It's pretty confusing on the landing page that it's full of duplicated repositories, e.g. in the attached screenshot

The code already had a Todo in place, and some of the issues / PRs mentioned code snippets used during repository cleanups, I put them into this PR.

## Related Issue

https://github.com/codetriage/CodeTriage/issues/1704#issuecomment-1272840699
https://github.com/codetriage/CodeTriage/issues/824#issuecomment-499686203
https://github.com/codetriage/CodeTriage/issues/1791 (and a few others...)

## Motivation and Context

It helps people find the right repository, for example mozilla/rust has 244 subscribers and rust-lang/rust has 308, though these two repos are the same.

## How Has This Been Tested?

I updated the existing test suite.

## Screenshots (if appropriate):

![image](https://github.com/codetriage/CodeTriage/assets/1900366/23a0025c-1ca6-4863-a2e0-6c86aa59753f)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
