### PR TITLE
Update issue assignments to bigint

### DIFF
--- a/db/migrate/20260202160000_change_issues_id_to_bigint.rb
+++ b/db/migrate/20260202160000_change_issues_id_to_bigint.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class ChangeIssuesIdToBigint < ActiveRecord::Migration[7.0]
+  # Disable transaction to allow running on large tables without locking for too long
+  # You may want to run this during low-traffic periods
+  disable_ddl_transaction!
+
+  def up
+    # Change the id column from integer (serial) to bigint (bigserial)
+    # This is necessary because the issues table has exceeded the 32-bit integer limit
+    # Max integer: 2,147,483,647
+    # Max bigint: 9,223,372,036,854,775,807
+
+    safety_assured do
+      # Change the primary key column type
+      execute "ALTER TABLE issues ALTER COLUMN id TYPE bigint"
+
+      # Change the sequence type to bigint as well
+      execute "ALTER SEQUENCE issues_id_seq AS bigint"
+
+      # Also update foreign keys in issue_assignments that reference issues.id
+      execute "ALTER TABLE issue_assignments ALTER COLUMN issue_id TYPE bigint"
+    end
+  end
+
+  def down
+    safety_assured do
+      # Note: This could fail if there are values > 2,147,483,647
+      execute "ALTER TABLE issue_assignments ALTER COLUMN issue_id TYPE integer"
+      execute "ALTER SEQUENCE issues_id_seq AS integer"
+      execute "ALTER TABLE issues ALTER COLUMN id TYPE integer"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_28_065556) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_02_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -74,8 +74,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_28_065556) do
     t.index ["repo_id", "name", "path"], name: "index_doc_methods_on_repo_id_and_name_and_path", unique: true
   end
 
-  create_table "issue_assignments", id: :serial, force: :cascade do |t|
-    t.integer "issue_id"
+  create_table "issue_assignments", force: :cascade do |t|
+    t.bigint "issue_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "repo_subscription_id"
@@ -84,7 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_28_065556) do
     t.index ["repo_subscription_id", "delivered"], name: "index_issue_assignments_on_repo_subscription_id_and_delivered"
   end
 
-  create_table "issues", id: :serial, force: :cascade do |t|
+  create_table "issues", force: :cascade do |t|
     t.integer "comment_count"
     t.string "url"
     t.string "repo_name"


### PR DESCRIPTION
Fix issue

```
E, [2026-02-02T15:37:35.582127 #5] ERROR -- : [ActiveJob] [PopulateIssuesJob] [cffcb87a-a234-487b-9bf8-07fefe0c8213] Error performing PopulateIssuesJob (Job ID: cffcb87a-a234-487b-9bf8-07fefe0c8213) from Sidekiq(default) in 550.91ms: ActiveRecord::RangeError (PG::NumericValueOutOfRange: ERROR:  integer out of range
):
/app/vendor/bundle/ruby/3.2.0/gems/rack-mini-profiler-3.1.1/lib/patches/db/pg.rb:69:in `exec_params'
/app/vendor/bundle/ruby/3.2.0/gems/rack-mini-profiler-3.1.1/lib/patches/db/pg.rb:69:in `exec_params'
/app/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/connection_adapters/postgresql_adapter.rb:768:in `block (2 levels) in exec_no_cache'
/app/vendor/bundle/ruby/3.2.0/gems/activesupport-7.0.8/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
```
