### PR TITLE
Fix slop

### DIFF
--- a/db/migrate/20260202160000_change_issues_id_to_bigint.rb
+++ b/db/migrate/20260202160000_change_issues_id_to_bigint.rb
@@ -1,34 +1,24 @@
 # frozen_string_literal: true
 
 class ChangeIssuesIdToBigint < ActiveRecord::Migration[7.0]
-  # Disable transaction to allow running on large tables without locking for too long
-  # You may want to run this during low-traffic periods
-  disable_ddl_transaction!
-
   def up
     # Change the id column from integer (serial) to bigint (bigserial)
     # This is necessary because the issues table has exceeded the 32-bit integer limit
     # Max integer: 2,147,483,647
     # Max bigint: 9,223,372,036,854,775,807
 
-    safety_assured do
-      # Change the primary key column type
-      execute "ALTER TABLE issues ALTER COLUMN id TYPE bigint"
+    # Primary keys
+    change_column :issues, :id, :bigint
+    change_column :issue_assignments, :id, :bigint
 
-      # Change the sequence type to bigint as well
-      execute "ALTER SEQUENCE issues_id_seq AS bigint"
-
-      # Also update foreign keys in issue_assignments that reference issues.id
-      execute "ALTER TABLE issue_assignments ALTER COLUMN issue_id TYPE bigint"
-    end
+    # Foreign keys
+    change_column :issue_assignments, :issue_id, :bigint
   end
 
   def down
-    safety_assured do
-      # Note: This could fail if there are values > 2,147,483,647
-      execute "ALTER TABLE issue_assignments ALTER COLUMN issue_id TYPE integer"
-      execute "ALTER SEQUENCE issues_id_seq AS integer"
-      execute "ALTER TABLE issues ALTER COLUMN id TYPE integer"
-    end
+    # Note: This could fail if there are values > 2,147,483,647
+    change_column :issue_assignments, :issue_id, :integer
+    change_column :issue_assignments, :id, :integer
+    change_column :issues, :id, :integer
   end
 end


### PR DESCRIPTION
I don't have a `safety_assured` method (thanks Opus!) I ran migrations locally to validate they worked, so something about my flow must have triggered a change before the actual commit.

Deploying #1844 causes an error:

```
       -- safety_assured(nil)
       D, [2026-02-02T15:53:04.496858 #1236] DEBUG -- :    (1.4ms)  SELECT pg_advisory_unlock(3010662050404357335)
       rake aborted!
       StandardError: An error has occurred, all later migrations canceled: (StandardError)
       
       undefined method `safety_assured' for #<ChangeIssuesIdToBigint:0x00007f10e6d28d10 @name="ChangeIssuesIdToBigint", @version=20260202160000, @connection=nil>
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:964:in `block in method_missing'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:935:in `block in say_with_time'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:935:in `say_with_time'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:954:in `method_missing'
       /tmp/build_92292fc4/db/migrate/20260202160000_change_issues_id_to_bigint.rb:14:in `up'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:908:in `public_send'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:908:in `exec_migration'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:889:in `block (2 levels) in migrate'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/migration.rb:888:in `block in migrate'
       /tmp/build_92292fc4/vendor/bundle/ruby/3.2.0/gems/activerecord-7.0.8/lib/active_record/connection_adapters/abstract/connection_pool.rb:215:in 
```

I think this wasn't caught in CI since it loads from schema first instead of running all migrations.
