### PR TITLE
Replace uglifier with terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "sassc-rails"
 gem "slim-rails"
 gem "sprockets"
 gem "sprockets-rails"
-gem "uglifier", ">= 1.0.3"
+gem "terser"
 
 # Authentication & Authorization
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,6 +563,8 @@ GEM
       standard
     stringio (3.2.0)
     temple (0.10.4)
+    terser (1.2.6)
+      execjs (>= 0.3.0, < 3)
     test-prof (1.5.2)
     thor (1.5.0)
     tilt (2.7.0)
@@ -572,8 +574,6 @@ GEM
       bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -689,8 +689,8 @@ DEPENDENCIES
   stackprof
   standard (>= 1.35.1)
   standardrb
+  terser
   test-prof
-  uglifier (>= 1.0.3)
   valid_email
   vcr
   web-console
@@ -918,6 +918,7 @@ CHECKSUMS
   standardrb (1.0.1) sha256=7a1328be429f4e97a97e357e2446f3509e80164a59ff00bc6a4daa78e3351f2c
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   temple (0.10.4) sha256=b7a1e94b6f09038ab0b6e4fe0126996055da2c38bec53a8a336f075748fff72c
+  terser (1.2.6) sha256=6ddf00b93df7015b07e2b9b149e74cd70fa7aa4f0f89a15d9922a6ebd13f37ab
   test-prof (1.5.2) sha256=185839fb7d3745b3770ec48e3e5718eff9e28c327a50a1e18a3a9ef1060f8576
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
@@ -925,7 +926,6 @@ CHECKSUMS
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   ttfunk (1.8.0) sha256=a7cbc7e489cc46e979dde04d34b5b9e4f5c8f1ee5fc6b1a7be39b829919d20ca
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  uglifier (4.2.1) sha256=75d42b81b10bfd21e7a427fabb1d49ff5ea7bda3c4a5039ddb2a78d194c6f5aa
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Before

```
       D, [2026-02-04T16:21:44.038948 #5680] DEBUG -- sentry: Sentry HTTP Transport will connect to https://sentry.io
       D, [2026-02-04T16:21:44.039009 #5680] DEBUG -- sentry: [Sentry::MetricEventBuffer] Initialized buffer with max_items=1000, flush_interval=5s
       D, [2026-02-04T16:21:44.039129 #5680] DEBUG -- sentry: Initializing the Sentry background worker with 2 threads
       D, [2026-02-04T16:21:44.039195 #5680] DEBUG -- sentry: [Sessions] Sessions won't be captured without a valid release
       D, [2026-02-04T16:21:44.099603 #5680] DEBUG -- : [Judoscale] No reporting since we're in a build process
       W, [2026-02-04T16:21:44.110880 #5680]  WARN -- : Generating image variants require the image_processing gem. Please add `gem "image_processing", "~> 1.2"` to your Gemfile or set `config.active_storage.variant_processor = :disabled`.
       rake aborted!
       Uglifier::Error: Unexpected token: punc (.) (Uglifier::Error)
       --
        11566   };
        11567
        11568   if (window.jQuery) {
        11569     jqueryUjsInit(jQuery);
        11570   } else if (typeof exports === 'object' && typeof module === 'object') {
        11571     module.exports = jqueryUjsInit;
        11572   }
        11573 })();
           => !function(t,e){"object"==typeof exports&&"undefined"!=typeof module?module.exports=e():"function"==typeof define&&define.amd?define(e):(t="undefined"!=typeof globalThis?globalThis:t||self).LocalTime=e()}(this,(function(){"use strict";const t={config:{},run(){this.getController().processElements()},process(...t){for(const e of t)this.getController().processElement(e);return t.length},getController(){return this.controller?this.controller:this.controller=new t.Controller}};t.config.useFormat24=!1,t.config.i18n={en:{date:{dayNames:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],abbrDayNames:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],monthNames:["January","February","March","April","May","June","July","August","September","October","November","December"],abbrMonthNames:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],yesterday:"yesterday",today:"today",tomorrow:"tomorrow",on:"on {date}",formats:{default:"%b %e, %Y",thisYear:"%b %e"}},time:{am:"am",pm:"pm",singular:"a {time}",singularAn:"an {time}",elapsed:"{time} ago",second:"second",seconds:"seconds",minute:"minute",minutes:"minutes",hour:"hour",hours:"hours",formats:{default:"%l:%M%P",default_24h:"%H:%M"}},datetime:{at:"{date} at {time}",formats:{default:"%B %e, %Y at %l:%M%P %Z",default_24h:"%B %e, %Y at %H:%M %Z"}}}},t.config.locale="en",t.config.defaultLocale="en",t.config.timerInterval=6e4;const e=!isNaN(Date.parse("2011-01-01T12:00:00-05:00"));t.parseDate=t=>(t=t.toString(),e||(t=function(t){const e=t.match(r);if(e){let t;const[r,a,s,n,i,o,c,u]=e;return"Z"!==u&&(t=u.replace(":","")),`${a}/${s}/${n} ${i}:${o}:${c} GMT${[t]}`}}(t)),new Date(Date.parse(t)));const r=/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(Z|[-+]?[\d:]+)$/;t.elementMatchesSelector=(()=>{const t=document.documentElement,e=t.matches||t.matchesSelector||t.webkitMatchesSelector||t.mozMatchesSelector||t.msMatchesSelector;return(t,r)=>{if(t?.nodeType===Node.ELEMENT_NODE)return e.call(t,r)}})();const{config:a}=t,{i18n:s}=a;t.getI18nValue=(e="",r={locale:a.locale})=>{const{locale:n}=r,i=function(t,e){let r=t;for(var a of Array.from(e.split("."))){if(!r[a])return null;r=r[a]}return r}(s[n],e);return i||(n!==a.defaultLocale?t.getI18nValue(e,{locale:a.defaultLocale}):void 0)},t.translate=(e,r={},a)=>{let s=t.getI18nValue(e,a);for(const t in r){const e=r[t];s=s.replace(`{${t}}`,e)}return s};const{getI18nValue:n,translate:i}=t,o="function"==typeof Intl?.DateTimeFormat,c={"Central European Standard Time":"CET","Central European Summer Time":"CEST","China Standard Time":"CST","Israel Daylight Time":"IDT","Israel Standard Time":"IST","Moscow Standard Time":"MSK","Peru Standard Time":"PET","Philippine Standard Time":"PHT","Singapore Standard Time":"SGT","Western Indonesia Time":"WIB"};t.knownEdgeCaseTimeZones=c,t.strftime=(()=>{const t=(a,s)=>{const u=a.getDay(),l=a.getDate(),d=a.getMonth(),m=a.getFullYear(),h=a.getHours(),f=a.getMinutes(),g=a.getSeconds();return s.replace(/%(-?)([%aAbBcdeHIlmMpPSwyYZ])/g,((s,p,y)=>{switch(y){case"%":return"%";case"a":return n("date.abbrDayNames")[u];case"A":return n("date.dayNames")[u];case"b":return n("date.abbrMonthNames")[d];case"B":return n("date.monthNames")[d];case"c":return a.toString();case"d":return e(l,p);case"e":return l;case"H":return e(h,p);case"I":return e(t(a,"%l"),p);case"l":return 0===h||12===h?12:(h+12)%12;case"m":return e(d+1,p);case"M":return e(f,p);case"p":return i("time."+(h>11?"pm":"am")).toUpperCase();case"P":return i("time."+(h>11?"pm":"am"));case"S":return e(g,p);case"w":return u;case"y":return e(m%100,p);case"Y":return m;case"Z":return function(t){let e,a,s;return(a=function(t){return Object.keys(c).find((e=>o?new Date(t).toLocaleString("en-US",{timeZoneName:"long"}).includes(e):t.toString().includes(e)))}(t))?c[a]:(s=r(t,{allowGMT:!1}))||(s=function(t){const e=t.toString();let r;if(null!=(r=e.match(/\(([\w\s]+)\)$/))){const t=r[1];return/\s/.test(t)?t.match(/\b(\w)/g).join(""):t}if(null!=(r=e.match(/(\w{3,4})\s\d{4}$/)))return r[1];if(null!=(r=e.match(/(UTC[\+\-]\d+)/)))return r[1]}(t))?s:(e=r(t,{allowGMT:!0}))?e:""}(a)}}))};function e(t,e){return"-"===e?t:`0${t}`.slice(-2)}function r(t,{allowGMT:e}){if(o){const r=new Date(t).toLocaleString("en-US",{timeZoneName:"short"}).split(" ").pop();if(e||!r.includes("GMT"))return r}}return t})(),t.CalendarDate=class{static fromDate(t){return new this(t.getFullYear(),t.getMonth()+1,t.getDate())}static today(){return this.fromDate(new Date)}constructor(t,e,r){this.date=new Date(Date.UTC(t,e-1)),this.date.setUTCDate(r),this.year=this.date.getUTCFullYear(),this.month=this.date.getUTCMonth()+1,this.day=this.date.getUTCDate(),this.value=this.date.getTime()}equals(t){return t?.value===this.value}is(t){return this.equals(t)}isToday(){return this.is(this.constructor.today())}occursOnSameYearAs(t){return this.year===t?.year}occursThisYear(){return this.occursOnSameYearAs(this.constructor.today())}daysSince(t){if(t)return(this.date-t.date)/864e5}daysPassed(){return this.constructor.today().daysSince(this)}};const{strftime:u,translate:l,getI18nValue:d,config:m}=t;t.RelativeTime=class{constructor(e){this.date=e,this.calendarDate=t.CalendarDate.fromDate(this.date)}toString(){let t,e;return(e=this.toTimeElapsedString())?l("time.elapsed",{time:e}):(t=this.toWeekdayString())?(e=this.toTimeString(),l("datetime.at",{date:t,time:e})):l("date.on",{date:this.toDateString()})}toTimeOrDateString(){return this.calendarDate.isToday()?this.toTimeString():this.toDateString()}toTimeElapsedString(){let t;const e=(new Date).getTime()-this.date.getTime(),r=Math.round(e/1e3),a=Math.round(r/60),s=Math.round(a/60);return e<0?null:r<10?(t=l("time.second"),l("time.singular",{time:t})):r<45?`${r} ${l("time.seconds")}`:r<90?(t=l("time.minute"),l("time.singular",{time:t})):a<45?`${a} ${l("time.minutes")}`:a<90?(t=l("time.hour"),l("time.singularAn",{time:t})):s<24?`${s} ${l("time.hours")}`:""}toWeekdayString(){switch(this.calendarDate.daysPassed()){case 0:return l("date.today");case 1:return l("date.yesterday");case-1:return l("date.tomorrow");case 2:case 3:case 4:case 5:case 6:return u(this.date,"%A");default:return""}}toDateString(){const t=this.calendarDate.occursThisYear()?d("date.formats.thisYear"):d("date.formats.default");return u(this.date,t)}toTimeString(){const t=m.useFormat24?"default_24h":"default";return u(this.date,d(`time.formats.${t}`))}};const{elementMatchesSelector:h}=t;t.PageObserver=class{constructor(t,e){this.selector=t,this.callback=e,this.processMutations=this.processMutations.bind(this),this.processInsertion=this.processInsertion.bind(this)}start(){this.started||(this.observeWithMutationObserver()||this.observeWithMutationEvent(),this.started=!0)}observeWithMutationObserver(){if("undefined"!=typeof MutationObserver&&null!==MutationObserver){return new MutationObserver(this.processMutations).observe(document.documentElement,{childList:!0,subtree:!0}),!0}return!1}observeWithMutationEvent(){return addEventListener("DOMNodeInserted",this.processInsertion,!1),!0}findSignificantElements(t){const e=[];return t?.nodeType===Node.ELEMENT_NODE&&(h(t,this.selector)&&e.push(t),e.push(...Array.from(t.querySelectorAll(this.selector)||[]))),e}processMutations(t){const e=[];for(const r of t)if("childList"===r.type)for(const t of r.addedNodes)e.push(...this.findSignificantElements(t)||[]);this.notify(e)}processInsertion(t){const e=this.findSignificantElements(t.target);this.notify(e)}notify(t){t?.length>0&&"function"==typeof this.callback&&this.callback(t)}};const{parseDate:f,strftime:g,getI18nValue:p,config:y}=t,S="time[data-local]:not([data-localized])",T=t=>t.setAttribute("data-localized",""),b=e=>new t.RelativeTime(e);t.Controller=class{constructor(){this.processElements=this.processElements.bind(this),this.pageObserver=new t.PageObserver(S,this.processElements)}start(){this.started||(this.processElements(),this.startTimer(),this.pageObserver.start(),this.started=!0)}startTimer(){let t;(t=y.timerInterval)&&(this.timer||(this.timer=setInterval(this.processElements,t)))}processElements(t){t||(t=document.querySelectorAll(S));for(const e of Array.from(t))this.processElement(e);return t.length}processElement(t){const e=t.getAttribute("datetime"),r=t.getAttribute("data-local"),a=y.useFormat24&&t.getAttribute("data-format24")||t.getAttribute("data-format"),s=f(e);if(!isNaN(s)){if(!t.hasAttribute("title")){const e=y.useFormat24?"default_24h":"default",r=g(s,p(`datetime.formats.${e}`));t.setAttribute("title",r)}(t=>{t.setAttribute("data-processed-at",(new Date).toISOString())})(t),t.textContent=(()=>{switch(r){case"time":return T(t),g(s,a);case"date":return T(t),b(s).toDateString();case"time-ago":return b(s).toString();case"time-or-date":return b(s).toTimeOrDateString();case"weekday":return b(s).toWeekdayString();case"weekday-or-date":return b(s).toWeekdayString()||b(s).toDateString()}})()}}};let M=!1;function D(){t.getController().start()}return t.start=()=>{var e;M?t.run():(M=!0,"undefined"!=typeof MutationObserver&&null!==MutationObserver||(document.attachEvent?"complete"===document.readyState:"loading"!==document.readyState)?D():(e=D,"function"==typeof requestAnimationFrame?requestAnimationFrame(e):setTimeout(e,17)))},t.processing=()=>t.getController().started,window.LocalTime===t&&t.start(),t}));
        11575 /*!
        11576  * Bootstrap v3.3.7 (http://getbootstrap.com)
        11577  * Copyright 2011-2017 Twitter, Inc.
        11578  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
        11579  */
        11580
        11581 /*!
        11582  * Generated using the Bootstrap Customizer (http://getbootstrap.com/customize/?id=6eccc3db33edecd9f0615ab607810de7)
       ==
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/uglifier-4.2.1/lib/uglifier.rb:291:in 'Uglifier#parse_result'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/uglifier-4.2.1/lib/uglifier.rb:221:in 'Uglifier#run_uglifyjs'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/uglifier-4.2.1/lib/uglifier.rb:166:in 'Uglifier#compile'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/compressing.rb:84:in 'block in Sprockets::Compressing#js_compressor='
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:84:in 'Sprockets::ProcessorUtils#call_processor'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:66:in 'block in Sprockets::ProcessorUtils#call_processors'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:65:in 'Array#reverse_each'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:65:in 'Sprockets::ProcessorUtils#call_processors'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:184:in 'Sprockets::Loader#load_from_unloaded'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:59:in 'block in Sprockets::Loader#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:339:in 'Sprockets::Loader#fetch_asset_from_dependency_cache'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:43:in 'Sprockets::Loader#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/cached_environment.rb:44:in 'block in Sprockets::CachedEnvironment#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:207:in 'block in Concurrent::Map#fetch_or_store'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:187:in 'Concurrent::Map#fetch'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:206:in 'Concurrent::Map#fetch_or_store'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/cached_environment.rb:44:in 'Sprockets::CachedEnvironment#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/bundle.rb:32:in 'block in Sprockets::Bundle.call'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/bundle.rb:31:in 'Set#each'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/bundle.rb:31:in 'Sprockets::Bundle.call'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:84:in 'Sprockets::ProcessorUtils#call_processor'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:66:in 'block in Sprockets::ProcessorUtils#call_processors'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:65:in 'Array#reverse_each'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/processor_utils.rb:65:in 'Sprockets::ProcessorUtils#call_processors'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:184:in 'Sprockets::Loader#load_from_unloaded'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:59:in 'block in Sprockets::Loader#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:339:in 'Sprockets::Loader#fetch_asset_from_dependency_cache'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/loader.rb:43:in 'Sprockets::Loader#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/cached_environment.rb:44:in 'block in Sprockets::CachedEnvironment#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:207:in 'block in Concurrent::Map#fetch_or_store'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:187:in 'Concurrent::Map#fetch'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:206:in 'Concurrent::Map#fetch_or_store'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/cached_environment.rb:44:in 'Sprockets::CachedEnvironment#load'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/base.rb:81:in 'Sprockets::Base#find_asset'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/base.rb:88:in 'Sprockets::Base#find_all_linked_assets'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/manifest.rb:125:in 'Enumerator#each'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/manifest.rb:125:in 'Enumerable#to_a'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/sprockets-4.2.2/lib/sprockets/manifest.rb:125:in 'block (2 levels) in Sprockets::Manifest#find'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:24:in 'block in Concurrent::SafeTaskExecutor#execute'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'block in Concurrent::Synchronization::MutexLockableObject#synchronize'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'Thread::Mutex#synchronize'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:48:in 'Concurrent::Synchronization::MutexLockableObject#synchronize'
       /tmp/build_945d809a/vendor/bundle/ruby/4.0.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:22:in 'Concurrent::SafeTaskExecutor#execute'
       /tmp/build_945d
```

After:

```
$ SECRET_KEY_BASE=dummy_key_for_asset_precompile_test RAILS_ENV=production bin/rake assets:precompile
$ echo $?
0
```
