### PR TITLE
Update PhantomJS Homebrew installation command.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,8 @@ CodeTriage requires Redis for background processing.
 If you're on OS X, Homebrew is the simplest way to install Redis:
 
 ```shell
-$ brew install redis memcached && brew cask install phantomjs
+$ brew install redis memcached
+$ brew install --cask phantomjs
 $ redis-server
 ```
 


### PR DESCRIPTION
## Description

Updated the outdated Homebrew PhantomJS installation command in `CONTRIBUTING.md`.

## Related Issue

Fixes #1866

## Motivation and Context

The previous command used the deprecated `brew cask install phantomjs` syntax. This PR updates it to the current Homebrew syntax using `brew install --cask phantomjs`.

## How Has This Been Tested?

Reviewed the updated command syntax and verified the documentation change.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the code style of this project.
* [x] My change requires a change to the documentation.
* [x] I have updated the documentation accordingly.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
